### PR TITLE
Implement configurable styles in yapf.

### DIFF
--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -47,6 +47,10 @@ def main(argv):
     0 if there were no errors, non-zero otherwise.
   """
   parser = argparse.ArgumentParser(description='Formatter for Python code.')
+  parser.add_argument(
+      '--style', action='store', default=None,
+      help=('specify formatting style: either a style name (for example "pep8" '
+            'or "google"), or the name of a file with style settings'))
   diff_inplace_group = parser.add_mutually_exclusive_group()
   diff_inplace_group.add_argument(
       '-d', '--diff', action='store_true',
@@ -90,14 +94,15 @@ def main(argv):
     sys.stdout.write(yapf_api.FormatCode(
         py3compat.unicode('\n'.join(original_source) + '\n'),
         filename='<stdin>',
+        style_config=args.style,
         lines=lines))
     return 0
 
-  FormatFiles(files, lines, args.in_place)
+  FormatFiles(files, lines, style_config=args.style, in_place=args.in_place)
   return 0
 
 
-def FormatFiles(filenames, lines, in_place=False):
+def FormatFiles(filenames, lines, style_config=None, in_place=False):
   """Format a list of files.
 
   Arguments:
@@ -106,11 +111,13 @@ def FormatFiles(filenames, lines, in_place=False):
       that we want to format. The lines are 1-based indexed. This argument
       overrides the 'args.lines'. It can be used by third-party code (e.g.,
       IDEs) when reformatting a snippet of code.
+    style_config: (string) Style name or file path.
     in_place: (bool) Modify the files in place.
   """
   for filename in filenames:
     logging.info('Reformatting %s', filename)
-    reformatted_code = yapf_api.FormatFile(filename, lines)
+    reformatted_code = yapf_api.FormatFile(
+        filename, style_config=style_config, lines=lines)
     if reformatted_code is not None:
       file_resources.WriteReformattedCode(filename, reformatted_code, in_place)
 

--- a/yapf/yapflib/py3compat.py
+++ b/yapf/yapflib/py3compat.py
@@ -26,6 +26,8 @@ if PY3:
   range = range
   ifilter = filter
   raw_input = input
+
+  import configparser
 else:
   import __builtin__
   import cStringIO
@@ -35,6 +37,8 @@ else:
 
   from itertools import ifilter
   raw_input = raw_input
+
+  import ConfigParser as configparser
 
 
 def EncodeForStdout(s):
@@ -50,10 +54,18 @@ def EncodeForStdout(s):
     return s.encode('UTF-8')
 
 
-
 def unicode(s):
   """Force conversion of s to unicode."""
   if PY3:
     return s
   else:
     return __builtin__.unicode(s, "unicode_escape")
+
+
+# In Python 3.2+, readfp is deprecated in favor of read_file, which doesn't
+# exist in Python 2 yet. To avoid deprecation warnings, subclass ConfigParser to
+# fix this - now read_file works across all Python versions we care about.
+class ConfigParser(configparser.ConfigParser):
+  if not PY3:
+    def read_file(self, fp, source=None):
+      self.readfp(fp, filename=source)

--- a/yapf/yapflib/yapf_api.py
+++ b/yapf/yapflib/yapf_api.py
@@ -43,6 +43,7 @@ from yapf.yapflib import pytree_unwrapper
 from yapf.yapflib import pytree_utils
 from yapf.yapflib import reformatter
 from yapf.yapflib import split_penalty
+from yapf.yapflib import style
 from yapf.yapflib import subtype_assigner
 
 

--- a/yapf/yapflib/yapf_api.py
+++ b/yapf/yapflib/yapf_api.py
@@ -17,6 +17,18 @@ The main APIs that YAPF exposes to drive the reformatting.
 
   FormatFile(): reformat a file.
   FormatCode(): reformat a string of code.
+
+These APIs have some common arguments:
+
+  style_config: (string) Either a style name or a path to a file that contains
+    formatting style settings. If None is specified, use the default style
+    as set in style.DEFAULT_STYLE_FACTORY
+  lines: (list of tuples of integers) A list of tuples of lines, [start, end],
+    that we want to format. The lines are 1-based indexed. It can be used by
+    third-party code (e.g., IDEs) when reformatting a snippet of code rather
+    than a whole file.
+  print_diff: (bool) Instead of returning the reformatted source, return a
+    diff that turns the formatted source into reformatter source.
 """
 
 import difflib
@@ -35,16 +47,12 @@ from yapf.yapflib import style
 from yapf.yapflib import subtype_assigner
 
 
-def FormatFile(filename, lines=None, print_diff=False):
+def FormatFile(filename, style_config=None, lines=None, print_diff=False):
   """Format a single Python file and return the formatted code.
 
   Arguments:
     filename: (unicode) The file to reformat.
-    lines: (list of tuples of integers) A list of tuples of lines, [start, end],
-      that we want to format. The lines are 1-based indexed. This argument
-      overrides the 'FLAGS.lines'. It can be used by third-party code (e.g.,
-      IDEs) when reformatting a snippet of code.
-    print_diff: (bool) Print the diff for the fixed source.
+    style_config, lines, print_diff: see comment at the top of this module.
 
   Returns:
     The reformatted code or None if the file doesn't exist.
@@ -53,12 +61,12 @@ def FormatFile(filename, lines=None, print_diff=False):
   if original_source is None:
     return None
 
-  return FormatCode(original_source, filename=filename, lines=lines,
-                    print_diff=print_diff)
+  return FormatCode(original_source, style_config=style_config,
+                    filename=filename, lines=lines, print_diff=print_diff)
 
 
-def FormatCode(unformatted_source, filename='<unknown>', lines=None,
-               print_diff=False):
+def FormatCode(unformatted_source, filename='<unknown>', style_config=None,
+               lines=None, print_diff=False):
   """Format a string of Python code.
 
   This provides an alternative entry point to YAPF.
@@ -66,15 +74,12 @@ def FormatCode(unformatted_source, filename='<unknown>', lines=None,
   Arguments:
     unformatted_source: (unicode) The code to format.
     filename: (unicode) The name of the file being reformatted.
-    lines: (list of tuples of integers) A list of tuples of lines, [start, end],
-      that we want to format. The lines are 1-based indexed. This argument
-      overrides the 'FLAGS.lines'. It can be used by third-party code (e.g.,
-      IDEs) when reformatting a snippet of code.
-    print_diff: (bool) Print the diff for the fixed source.
+    style_config, lines, print_diff: see comment at the top of this module.
 
   Returns:
     The code reformatted to conform to the desired formatting style.
   """
+  style.SetGlobalStyle(style.CreateStyleFromConfig(style_config))
   tree = pytree_utils.ParseCodeToTree(unformatted_source)
 
   # Run passes on the tree, modifying it in place.

--- a/yapftests/__init__.py
+++ b/yapftests/__init__.py
@@ -18,6 +18,7 @@ import unittest
 from yapftests import blank_line_calculator_test
 from yapftests import blank_line_calculator_test
 from yapftests import comment_splicer_test
+from yapftests import file_resources_test
 from yapftests import format_decision_state_test
 from yapftests import format_token_test
 from yapftests import line_joiner_test
@@ -26,6 +27,7 @@ from yapftests import pytree_utils_test
 from yapftests import pytree_visitor_test
 from yapftests import reformatter_test
 from yapftests import split_penalty_test
+from yapftests import style_test
 from yapftests import subtype_assigner_test
 from yapftests import unwrapped_line_test
 from yapftests import yapf_test
@@ -36,6 +38,7 @@ def suite():
   result.addTests(blank_line_calculator_test.suite())
   result.addTests(blank_line_calculator_test.suite())
   result.addTests(comment_splicer_test.suite())
+  result.addTests(file_resources_test.suite())
   result.addTests(format_decision_state_test.suite())
   result.addTests(format_token_test.suite())
   result.addTests(line_joiner_test.suite())
@@ -44,6 +47,7 @@ def suite():
   result.addTests(pytree_visitor_test.suite())
   result.addTests(reformatter_test.suite())
   result.addTests(split_penalty_test.suite())
+  result.addTests(style_test.suite())
   result.addTests(subtype_assigner_test.suite())
   result.addTests(unwrapped_line_test.suite())
   result.addTests(yapf_test.suite())

--- a/yapftests/file_resources_test.py
+++ b/yapftests/file_resources_test.py
@@ -37,11 +37,13 @@ def stdout_redirector(stream):
 
 class WriteReformattedCodeTest(unittest.TestCase):
 
-  def setUp(self):
-    self.test_tmpdir = tempfile.mkdtemp()
+  @classmethod
+  def setUpClass(cls):
+    cls.test_tmpdir = tempfile.mkdtemp()
 
-  def tearDown(self):
-    shutil.rmtree(self.test_tmpdir)
+  @classmethod
+  def tearDownClass(cls):
+    shutil.rmtree(cls.test_tmpdir)
 
   def testWriteToFile(self):
     s = u'foobar'
@@ -58,6 +60,12 @@ class WriteReformattedCodeTest(unittest.TestCase):
     with stdout_redirector(stream):
       file_resources.WriteReformattedCode(None, s, in_place=False)
     self.assertEqual(stream.getvalue(), s)
+
+
+def suite():
+  result = unittest.TestSuite()
+  result.addTests(unittest.makeSuite(WriteReformattedCodeTest))
+  return result
 
 
 if __name__ == '__main__':

--- a/yapftests/style_test.py
+++ b/yapftests/style_test.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for yapf.style"""
+
+import contextlib
+import shutil
+import tempfile
+import textwrap
+import unittest
+
+from yapf.yapflib import style
+
+
+class UtilsTest(unittest.TestCase):
+
+  def test_StringListConverter(self):
+    self.assertEqual(style._StringListConverter('foo, bar'), ['foo', 'bar'])
+    self.assertEqual(style._StringListConverter('foo,bar'), ['foo', 'bar'])
+    self.assertEqual(style._StringListConverter('  foo'), ['foo'])
+    self.assertEqual(style._StringListConverter('joe  ,foo,  bar'),
+                     ['joe', 'foo', 'bar'])
+
+  def test_BoolConverter(self):
+    self.assertEqual(style._BoolConverter('true'), True)
+    self.assertEqual(style._BoolConverter('1'), True)
+    self.assertEqual(style._BoolConverter('false'), False)
+    self.assertEqual(style._BoolConverter('0'), False)
+
+
+def _LooksLikeGoogleStyle(cfg):
+  return (cfg['INDENT_WIDTH'] == 2 and
+          not cfg['NO_BLANK_LINE_AFTER_CLASS_OR_DEF'])
+
+
+def _LooksLikePEP8Style(cfg):
+  return cfg['INDENT_WIDTH'] == 4 and cfg['NO_BLANK_LINE_AFTER_CLASS_OR_DEF']
+  
+
+class PredefinedStylesByNameTest(unittest.TestCase):
+
+  def test_Default(self):
+    # default is PEP8
+    cfg = style.CreateStyleFromConfig(None)
+    self.assertTrue(_LooksLikePEP8Style(cfg))
+
+  def test_GoogleByName(self):
+    for google_name in ('google', 'Google', 'GOOGLE'):
+      cfg = style.CreateStyleFromConfig(google_name)
+      self.assertTrue(_LooksLikeGoogleStyle(cfg))
+
+  def test_PEP8ByName(self):
+    for pep8_name in ('PEP8', 'pep8', 'Pep8'):
+      cfg = style.CreateStyleFromConfig(pep8_name)
+      self.assertTrue(_LooksLikePEP8Style(cfg))
+
+
+@contextlib.contextmanager
+def _TempFileContents(dir, contents):
+  with tempfile.NamedTemporaryFile(dir=dir, mode='w') as f:
+    f.write(contents)
+    f.flush()
+    yield f
+  
+
+class StyleFromFileTest(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    cls.test_tmpdir = tempfile.mkdtemp()
+
+  @classmethod
+  def tearDownClass(cls):
+    shutil.rmtree(cls.test_tmpdir)
+
+  def test_DefaultBasedOnStyle(self):
+    cfg = textwrap.dedent('''\
+        [style]
+        tab_width = 20
+        ''')
+    with _TempFileContents(self.test_tmpdir, cfg) as f:
+      cfg = style.CreateStyleFromConfig(f.name)
+      self.assertTrue(_LooksLikePEP8Style(cfg))
+      self.assertEqual(cfg['TAB_WIDTH'], 20)
+
+  def test_DefaultBasedOnPEP8Style(self):
+    cfg = textwrap.dedent('''\
+        [style]
+        based_on_style = pep8
+        tab_width = 40
+        ''')
+    with _TempFileContents(self.test_tmpdir, cfg) as f:
+      cfg = style.CreateStyleFromConfig(f.name)
+      self.assertTrue(_LooksLikePEP8Style(cfg))
+      self.assertEqual(cfg['TAB_WIDTH'], 40)
+
+  def test_DefaultBasedOnGoogleStyle(self):
+    cfg = textwrap.dedent('''\
+        [style]
+        based_on_style = google
+        split_penalty_matching_bracket = 33
+        ''')
+    with _TempFileContents(self.test_tmpdir, cfg) as f:
+      cfg = style.CreateStyleFromConfig(f.name)
+      self.assertTrue(_LooksLikeGoogleStyle(cfg))
+      self.assertEqual(cfg['SPLIT_PENALTY_MATCHING_BRACKET'], 33)
+
+  def test_BoolOptionValue(self):
+    cfg = textwrap.dedent('''\
+        [style]
+        based_on_style = google
+        SPLIT_BEFORE_NAMED_ASSIGNS = False
+        split_before_logical_operator = true
+        ''')
+    with _TempFileContents(self.test_tmpdir, cfg) as f:
+      cfg = style.CreateStyleFromConfig(f.name)
+      self.assertTrue(_LooksLikeGoogleStyle(cfg))
+      self.assertEqual(cfg['SPLIT_BEFORE_NAMED_ASSIGNS'], False)
+      self.assertEqual(cfg['SPLIT_BEFORE_LOGICAL_OPERATOR'], True)
+
+  def test_StringListOptionValue(self):
+    cfg = textwrap.dedent('''\
+        [style]
+        based_on_style = google
+        I18N_FUNCTION_CALL = N_, V_, T_
+        ''')
+    with _TempFileContents(self.test_tmpdir, cfg) as f:
+      cfg = style.CreateStyleFromConfig(f.name)
+      self.assertTrue(_LooksLikeGoogleStyle(cfg))
+      self.assertEqual(cfg['I18N_FUNCTION_CALL'], ['N_', 'V_', 'T_'])
+
+
+def suite():
+  result = unittest.TestSuite()
+  result.addTests(unittest.makeSuite(UtilsTest))
+  result.addTests(unittest.makeSuite(PredefinedStylesByNameTest))
+  result.addTests(unittest.makeSuite(StyleFromFileTest))
+  return result
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Idea similar to clang-format: there's a set of supported "known" styles - for
the moment PEP8 and Google. For custom stuff, a configuration file can be
specified.