### PR TITLE
Opens the README.rst file with an explicit encoding.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import codecs
 import unittest
 from distutils.core import setup, Command
 
@@ -36,7 +37,7 @@ class RunTests(Command):
     runner.run(tests)
 
 
-with open('README.rst', 'r') as fd:
+with codecs.open('README.rst', 'r', 'utf-8') as fd:
   setup(
       name='yapf',
       version=yapf.__version__,


### PR DESCRIPTION
This is important because of the difference between bytes and strings
and the follies of `sys.getdefaultencoding()` in guessing the
appropriate encoding. Be explicit; use the utf-8 encoding for the
README.rst file, and decode it explicitly as utf-8-encoded text.

Uses the `codecs.open` function for cross-compatibility between Python 2
and Python 3. In Python 3, `open` takes a keyword argument of
`encoding`, but unfortunately `open` in Python 2 does not. `codecs.open`
solves this issue by taking an explicit encoding as an argument and by
being available in the standard library in both Python 2 and Python 3.

This may not seem to matter right now, but as soon as someone puts a
non-ASCII character in the README.rst file, you'll find decoding errors
will prevent some Python 3 users from being able to install the package
at all.