### PR TITLE
Take into account __future__ imports and pass flags to compile()

### DIFF
--- a/yapf/yapflib/reformatter.py
+++ b/yapf/yapflib/reformatter.py
@@ -20,10 +20,16 @@ as a string.
   Reformat(): the main function exported by this module.
 """
 
+import __future__
+import tokenize
 import collections
 import heapq
 import re
 
+try:
+  from StringIO import StringIO
+except ImportError:
+  from io import StringIO
 from yapf.yapflib import format_decision_state
 from yapf.yapflib import line_joiner
 from yapf.yapflib import pytree_utils
@@ -31,7 +37,7 @@ from yapf.yapflib import style
 from yapf.yapflib import verifier
 
 
-def Reformat(uwlines):
+def Reformat(uwlines, unformatted_source=None):
   """Reformat the unwrapped lines.
 
   Arguments:
@@ -42,6 +48,8 @@ def Reformat(uwlines):
   """
   final_lines = []
   prev_last_uwline = None  # The previous line.
+  compile_flags = _ExtractFutureImports(unformatted_source) \
+                  if unformatted_source else 0
 
   for uwline in _SingleOrMergedLines(uwlines):
     first_token = uwline.first
@@ -70,7 +78,7 @@ def Reformat(uwlines):
       formatted_line.append(token.whitespace_prefix)
       formatted_line.append(token.value)
     formatted_code.append(''.join(formatted_line))
-    verifier.VerifyCode(formatted_code[-1])
+    verifier.VerifyCode(formatted_code[-1], compile_flags=compile_flags)
 
   return ''.join(formatted_code) + '\n'
 
@@ -457,3 +465,56 @@ def _NoBlankLinesBeforeCurrentToken(text, cur_token, prev_token):
     cur_token_lineno -= cur_token.value.count('\n')
   num_newlines = text.count('\n') if not prev_token.is_comment else 0
   return prev_token.lineno + num_newlines == cur_token_lineno - 1
+
+
+def _ExtractFutureImports(unformatted_source):
+  """
+  Establish which features have been imported from __future__
+  and return an integer value suitable for use in the compile()
+  'flags' parameter.
+  """
+  def get_all_imports(tokens, last_was_name=False):
+    """
+    Pop tokens until we get to a NAME type, then if it's an import
+    return it and recurse. If it's a newline or endmarker, end the
+    recursion. last_was_name makes sure that NAME tokens adjacent to
+    one another don't get returned, such as the 'as' and 'print2' tokens
+    in "print_function as print2".
+    """
+    while True:
+      t = next(tokens)
+      if t[0] == tokenize.NAME:
+        if not last_was_name:
+          return [t[1]] + get_all_imports(tokens, True)
+      elif t[0] in (tokenize.NEWLINE, tokenize.ENDMARKER):
+        return []
+      else:
+        last_was_name = False
+
+  flags = 0
+  tokens = tokenize.generate_tokens(
+    StringIO(unformatted_source).readline)
+  imports = []
+  try:
+    while True:
+      # from __future__ import has to be the first statement in a file
+      # https://docs.python.org/2/reference/simple_stmts.html#future
+      first_three_tokens = " ".join(
+        (next(tokens)[1], next(tokens)[1], next(tokens)[1]))
+      if first_three_tokens == "from __future__ import":
+        imports += get_all_imports(tokens)
+      else:
+        # Keep popping tokens until the end of the _logical_ line
+        # https://docs.python.org/2/library/tokenize.html#tokenize.NL
+        while True:
+          t = next(tokens)
+          if t[0] in (tokenize.NEWLINE, tokenize.ENDMARKER):
+            break
+  except StopIteration:
+    # We reached the end of the file
+    pass
+
+  for imp in imports:
+    if imp in __future__.all_feature_names:
+      flags |= getattr(__future__, imp).compiler_flag
+  return flags

--- a/yapf/yapflib/verifier.py
+++ b/yapf/yapflib/verifier.py
@@ -25,7 +25,7 @@ import sys
 import textwrap
 
 
-def VerifyCode(code):
+def VerifyCode(code, compile_flags=0):
   """Verify that the reformatted code is syntactically correct.
 
   Arguments:
@@ -35,14 +35,17 @@ def VerifyCode(code):
     SyntaxError if the code was reformatted incorrectly.
   """
   try:
-    compile(textwrap.dedent(code).encode('UTF-8'), '<string>', 'exec')
+    compile(textwrap.dedent(code).encode('UTF-8'),
+            '<string>', 'exec', flags=compile_flags)
   except SyntaxError:
     try:
-      ast.parse(textwrap.dedent(code.lstrip('\n')).lstrip(), '<string>', 'exec')
+      ast.parse(textwrap.dedent(code.lstrip('\n')).lstrip(),
+                '<string>', 'exec')
     except SyntaxError:
       try:
         normalized_code = _NormalizeCode(code)
-        compile(normalized_code.encode('UTF-8'), '<string>', 'exec')
+        compile(normalized_code.encode('UTF-8'),
+                '<string>', 'exec', flags=compile_flags)
       except SyntaxError:
         sys.stderr.write('INTERNAL ERROR: %s\n' % code)
         raise

--- a/yapf/yapflib/yapf_api.py
+++ b/yapf/yapflib/yapf_api.py
@@ -110,7 +110,8 @@ def FormatCode(unformatted_source,
       reformatted_source = _FormatLineSnippets(unformatted_source, uwlines,
                                                lines)
     else:
-      reformatted_source = reformatter.Reformat(uwlines)
+      reformatted_source = reformatter.Reformat(
+        uwlines, unformatted_source=unformatted_source)
 
   if unformatted_source == reformatted_source:
     return '' if print_diff else reformatted_source

--- a/yapftests/future_import_test.py
+++ b/yapftests/future_import_test.py
@@ -1,0 +1,99 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test for __future__ import code verification."""
+
+import __future__
+import textwrap
+import unittest
+
+from yapf.yapflib import yapf_api
+from yapf.yapflib import reformatter
+
+class FuturePrintTest(unittest.TestCase):
+
+  def testExtractSingleFutureImport(self):
+    """Extract a single import from __future__"""
+    code = textwrap.dedent("""\
+      from __future__ import print_function
+      """)
+    flags = reformatter._ExtractFutureImports(code)
+    self.assertEqual(flags, __future__.print_function.compiler_flag)
+
+  def testExtractMultipleFutureImportsLines(self):
+    """Extract multiple __future__ imports on separate lines"""
+    code = textwrap.dedent("""\
+      from __future__ import print_function
+      from __future__ import absolute_import
+      """)
+    flags = reformatter._ExtractFutureImports(code)
+    expected_flags = __future__.print_function.compiler_flag | \
+                     __future__.absolute_import.compiler_flag
+    self.assertEqual(flags, expected_flags)
+
+  def testExtractMultipleFutureImportsParentheses(self):
+    """Extract multiple __future__ imports within parentheses"""
+    code = textwrap.dedent("""\
+      from __future__ import (print_function, absolute_import)
+      """)
+    flags = reformatter._ExtractFutureImports(code)
+    expected_flags = __future__.print_function.compiler_flag | \
+                     __future__.absolute_import.compiler_flag
+    self.assertEqual(flags, expected_flags)
+
+  def testExtractMultipleFutureImportsParenthesesLines(self):
+    """Extract multiple __future__ imports within parentheses on two lines"""
+    code = textwrap.dedent("""\
+      from __future__ import (print_function,
+        absolute_import)
+      """)
+    flags = reformatter._ExtractFutureImports(code)
+    expected_flags = __future__.print_function.compiler_flag | \
+                     __future__.absolute_import.compiler_flag
+    self.assertEqual(flags, expected_flags)
+
+  def testExtractMultipleFutureImportsLinesEscape(self):
+    """Extract multiple __future__ imports with newline escaped"""
+    code = textwrap.dedent("""\
+      from __future__ import print_function, \
+        absolute_import
+      """)
+    flags = reformatter._ExtractFutureImports(code)
+    expected_flags = __future__.print_function.compiler_flag | \
+                     __future__.absolute_import.compiler_flag
+    self.assertEqual(flags, expected_flags)
+
+  def testExtractCorrectFutureImportsWhenImportedAsAnother(self):
+    """Extract only the correct imports when one is imported as another"""
+    code = textwrap.dedent("""\
+      from __future__ import print_function as absolute_import
+      """)
+    flags = reformatter._ExtractFutureImports(code)
+    self.assertEqual(flags, __future__.print_function.compiler_flag)
+
+  def testFuturePrintPassToFunction(self):
+    """
+    Pass print() to a function as print("x") is still valid w/o future import
+    """
+    code = textwrap.dedent("""\
+      from __future__ import print_function
+      def use_function(fnc):
+        fnc("test")
+      if __name__ == "__main__":
+        use_function(print)
+      """)
+
+    try:
+      yapf_api.FormatCode(code)
+    except SyntaxError:
+      self.fail("FormatCode() did not handle future import correctly.")


### PR DESCRIPTION
Fixes #53 by parsing the source for __future__ imports, then supplying the correct flags to compile().

This has the side-effect of changing the function signature for reformatter.Reformat() by allowing the unformatted_source to be passed in. This may not be ideal, so please let me know if you can see a more suitable way to get the compiler flags from where they're extracted from the source to the compile() calls in verifier.VerifyCode().

I have accepted the CLA.