### PR TITLE
Improve handling of filenames on the command line

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,3 +11,4 @@
 
 Bill Wendling <morbo@google.com>
 Eli Bendersky <eliben@google.com>
+Sam Clegg <sbc@google.com>

--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -37,6 +37,10 @@ from yapf.yapflib import yapf_api
 __version__ = '0.1'
 
 
+class YapfError(Exception):
+  pass
+
+
 def main(argv):
   """Main program.
 
@@ -86,8 +90,7 @@ def main(argv):
     parser.error('cannot use -l/--lines with more than one file')
 
   lines = _GetLines(args.lines) if args.lines is not None else None
-  files = file_resources.GetCommandLineFiles(argv[1:], args.recursive)
-  if not files:
+  if not args.files:
     # No arguments specified. Read code from stdin.
     if args.in_place or args.diff:
       parser.error('cannot use --in_place or --diff flags when reading '
@@ -111,6 +114,9 @@ def main(argv):
         verify=args.verify))
     return 0
 
+  files = file_resources.GetCommandLineFiles(args.files, args.recursive)
+  if not files:
+    raise YapfError('Input filenames did not match any python files')
   FormatFiles(files, lines, style_config=args.style, in_place=args.in_place,
               print_diff=args.diff, verify=args.verify)
   return 0

--- a/yapf/yapflib/file_resources.py
+++ b/yapf/yapflib/file_resources.py
@@ -26,7 +26,7 @@ from yapf.yapflib import py3compat
 
 def GetCommandLineFiles(command_line_file_list, recursive):
   """Return the list of files specified on the command line."""
-  return _FindFiles(command_line_file_list, recursive)
+  return _FindPythonFiles(command_line_file_list, recursive)
 
 
 def WriteReformattedCode(filename, reformatted_code, in_place):
@@ -49,7 +49,7 @@ def WriteReformattedCode(filename, reformatted_code, in_place):
     sys.stdout.write(py3compat.EncodeForStdout(reformatted_code))
 
 
-def _FindFiles(filenames, recursive):
+def _FindPythonFiles(filenames, recursive):
   """Find all Python files."""
   python_files = []
   for filename in filenames:

--- a/yapftests/main_test.py
+++ b/yapftests/main_test.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for yapf.__init__.main."""
+
+import unittest
+import yapf
+
+
+class MainTest(unittest.TestCase):
+
+  def testNoPythonFilesMatched(self):
+    with self.assertRaisesRegexp(yapf.YapfError,
+                                 'did not match any python files'):
+      yapf.main(['yapf', 'foo.c'])


### PR DESCRIPTION
Don't call GetCommandLineFiles unless there are positional
arguments (args.files), and only pass the positional parameters
(otherwise GetCommandLineFiles ends up processing all the args
as well).

Prior to this change if you run 'yapf -i foo.c' it will give you
the unhelpful error:
'cannot use --in_place or --diff flags when reading from stdin'

Add a unit test for this case. Would add here but would prefer
to use 'mock' and don't see a dependency on 'mock' yet.

Also, give a useful error message when positional paramters
are specified but not arguments were given.