### PR TITLE
Add .coverage to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,13 +18,17 @@
 # vim swap files
 .*.sw?
 .sw?
-#OS X specific files.
+# OS X specific files.
 .DS_store
 
 #==============================================================================#
+# Files to ignore
+#==============================================================================#
+/.coverage
+
 # Directories to ignore (do not add trailing '/'s, they skip symlinks).
 #==============================================================================#
-build
-dist
-.tox
-yapf.egg-info
+/build
+/dist
+/.tox
+/yapf.egg-info


### PR DESCRIPTION
This file is generated by the 'coverage' tool.

Also, add / to beginning of entries that should only
be ignored in the root of the repo.