### PR TITLE
Move builtin styles into config files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ with codecs.open('README.rst', 'r', 'utf-8') as fd:
       author='Google Inc.',
       maintainer='Bill Wendling',
       maintainer_email='morbo@google.com',
+      package_data={'yapf': ['styles/*.ini']},
       packages=['yapf', 'yapf.yapflib', 'yapftests'],
       classifiers=['Development Status :: 3 - Alpha',
                    'Environment :: Console',

--- a/yapf/styles/chromium.ini
+++ b/yapf/styles/chromium.ini
@@ -1,0 +1,3 @@
+[style]
+based_on_style = google
+indent_width = 2

--- a/yapf/styles/google.ini
+++ b/yapf/styles/google.ini
@@ -1,0 +1,8 @@
+[style]
+based_on_style = pep8
+align_closing_bracket_with_visual_indent = false
+column_limit = 80
+blank_line_before_nested_class_or_def = true
+i18n_comment = #\..*
+i18n_function_call = N_, _
+space_between_ending_comma_and_closing_bracket = false

--- a/yapf/styles/pep8.ini
+++ b/yapf/styles/pep8.ini
@@ -1,0 +1,71 @@
+[style]
+
+# Align closing bracket with visual indentation.
+align_closing_bracket_with_visual_indent = true
+
+# The column limit.
+column_limit = 79
+
+# The regex for an i18n comment. The presence of this comment stops
+# reformatting of that line, because the comments are required to be
+# next to the string they translate.
+i18n_comment = ''
+
+# The i18n function call names. The presence of this function stops
+# reformattting on that line, because the string it has cannot be moved
+# away from the i18n comment.
+i18n_function_call = ''
+
+# The number of columns to use for indentation.
+indent_width = 4
+
+# Indent width for line continuations.
+continuation_indent_width = 4
+
+# Insert a blank line before a 'def' or 'class' immediately nested within
+# another 'def' or 'class'.
+#
+# For example:
+#
+# class Foo:
+#                    # <------ this blank line
+#   def method():
+#     ...
+#
+blank_line_before_nested_class_or_def = false
+
+# Insert a space between the ending comma and closing bracket of a list
+# etc.
+space_between_ending_comma_and_closing_bracket = true
+
+# The number of spaces required before a trailing comment.
+spaces_before_comment = 2
+
+# Set to true to prefer splitting before 'and' or 'or' rather than
+# after.
+split_before_logical_operator = false
+
+# Split named assignments onto individual lines.
+split_before_named_assigns = true
+
+# The penalty for splitting the line after a unary operator.
+split_penalty_after_unary_operator = 100
+
+# The penalty for characters over the column limit.
+split_penalty_excess_character = 2000
+
+# The penalty of splitting the line around the 'and' and 'or' operators.
+split_penalty_logical_operator = 30
+
+# The penalty for not matching the splitting decision for the matching
+# bracket tokens. For instance, if there is a newline after the opening
+# bracket, we would tend to expect one before the closing bracket, and
+# vice versa.
+split_penalty_matching_bracket = 50
+
+# The penalty for splitting right after the opening bracket.
+split_penalty_after_opening_bracket = 30
+
+# The penalty incurred by adding a line split to the unwrapped line. The
+# more line splits added the higher the penalty.
+split_penalty_for_added_line_split = 30

--- a/yapftests/blank_line_calculator_test.py
+++ b/yapftests/blank_line_calculator_test.py
@@ -251,7 +251,7 @@ def _ParseAndUnwrap(code, dumptree=False):
   Returns:
     List of unwrapped lines.
   """
-  style.SetGlobalStyle(style.CreateChromiumStyle())
+  style.SetGlobalStyle(style.CreateStyleFromConfig('chromium'))
   tree = pytree_utils.ParseCodeToTree(code)
   comment_splicer.SpliceComments(tree)
   subtype_assigner.AssignSubtypes(tree)

--- a/yapftests/reformatter_test.py
+++ b/yapftests/reformatter_test.py
@@ -35,7 +35,7 @@ class BasicReformatterTest(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):
-    style.SetGlobalStyle(style.CreateChromiumStyle())
+    style.SetGlobalStyle(style.CreateStyleFromConfig('chromium'))
 
   def testSimple(self):
     unformatted_code = textwrap.dedent("""\
@@ -1161,7 +1161,7 @@ class BuganizerFixes(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):
-    style.SetGlobalStyle(style.CreateChromiumStyle())
+    style.SetGlobalStyle(style.CreateStyleFromConfig('chromium'))
 
   def testB20073838(self):
     code = textwrap.dedent("""\
@@ -1683,7 +1683,7 @@ class TestsForPEP8Style(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):
-    style.SetGlobalStyle(style.CreatePEP8Style())
+    style.SetGlobalStyle(style.CreateStyleFromConfig('pep8'))
 
   def testIndent4(self):
     unformatted_code = textwrap.dedent("""\
@@ -1829,7 +1829,7 @@ class TestVerifyNoVerify(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):
-    style.SetGlobalStyle(style.CreatePEP8Style())
+    style.SetGlobalStyle(style.CreateStyleFromConfig('pep8'))
 
   def testVerifyException(self):
     unformatted_code = textwrap.dedent("""\
@@ -1894,7 +1894,7 @@ class TestsForPython3Code(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):
-    style.SetGlobalStyle(style.CreatePEP8Style())
+    style.SetGlobalStyle(style.CreateStyleFromConfig('pep8'))
 
   def testKeywordOnlyArgSpecifier(self):
     unformatted_code = textwrap.dedent("""\

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -35,7 +35,7 @@ YAPF_BINARY = [sys.executable, '-m', 'yapf', '--verify', '--no-local-style']
 class YapfTest(unittest.TestCase):
 
   def _Check(self, unformatted_code, expected_formatted_code):
-    style.SetGlobalStyle(style.CreateChromiumStyle())
+    style.SetGlobalStyle(style.CreateStyleFromConfig('chromium'))
     formatted_code = yapf_api.FormatCode(unformatted_code)
     self.assertEqual(expected_formatted_code, formatted_code)
 


### PR DESCRIPTION
This change is quite a bit more intrusive than my previous few.  Feel free to push back if you don't like it.   It certainly makes sense to me this way (i didn't expect the style definitions in code when I first poked around the project).  On thing I wasn't sure about was the file extension to use for styles.  I went with .ini because this caused vim to choose the right syntax highlighting :)

For my next change I was thinking of having yapf look for a project wide style file (.yapf) that would work like .clang-format does..  again not sure if that fits with your direction, but I thought it would be useful for yapf itself for example.

Move the builtin styles into config files rather than hardcoding
them.  This allows them to be easily located and modified and
also to act as an example to those who want to write their own
styles.

It also keeps us honest and ensures we don't encode anything into
the builtin styles that cannot be parsed from the config file format.

It also allows new builtin styles to be added by simply dropping
files in the 'styles' directory.
