### PR TITLE
Honour disable/enable comments when --lines is set

### DIFF
--- a/yapf/yapflib/yapf_api.py
+++ b/yapf/yapflib/yapf_api.py
@@ -182,7 +182,6 @@ def _MarkLinesToFormat(uwlines, lines):
           break
         if uwline.lineno >= start:
           uwline.disable = False
-    return
 
   index = 0
   while index < len(uwlines):

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -561,6 +561,40 @@ class CommandLineTest(unittest.TestCase):
     self.assertIsNone(stderrdata)
     self.assertEqual(reformatted_code.decode('utf-8'), unformatted_code)
 
+  def testDisableWhenSpecifyingLines(self):
+    unformatted_code = textwrap.dedent(u"""\
+        # yapf: disable
+        A = set([
+            'hello',
+            'world',
+        ])
+        # yapf: enable
+        B = set([
+            'hello',
+            'world',
+        ])  # yapf: disable
+        """)
+    expected_formatted_code = textwrap.dedent(u"""\
+        # yapf: disable
+        A = set([
+            'hello',
+            'world',
+        ])
+        # yapf: enable
+        B = set([
+            'hello',
+            'world',
+        ])  # yapf: disable
+        """)
+
+    p = subprocess.Popen(YAPF_BINARY + ['--lines', '1-10'],
+                         stdout=subprocess.PIPE,
+                         stdin=subprocess.PIPE,
+                         stderr=subprocess.STDOUT)
+    reformatted_code, stderrdata = p.communicate(
+        unformatted_code.encode('utf-8'))
+    self.assertIsNone(stderrdata)
+    self.assertEqual(reformatted_code.decode('utf-8'), expected_formatted_code)
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Currently, when `--lines` is set, yapf ignores the enable/disable comments.

Is this the intended behaviour?

If not, this pull requests adds a testcase and fixes it.