### PR TITLE
Add --max-line-width and --indent-width

### DIFF
--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -62,6 +62,10 @@ def main(argv):
       help=('specify formatting style: either a style name (for example "pep8" '
             'or "google"), or the name of a file with style settings. pep8 is '
             'the default.'))
+  parser.add_argument('--max-line-width', type=int, default=0,
+                      help='override maximum line width')
+  parser.add_argument('--indent-width', type=int, default=0,
+                      help='override indent width')
   parser.add_argument('--verify',
                       action='store_true',
                       help='try to verify refomatted code for syntax errors')
@@ -91,6 +95,12 @@ def main(argv):
     print('yapf {}'.format(__version__))
     return 0
 
+  style_opts = {}
+  if args.max_line_width:
+    style_opts['COLUMN_LIMIT'] = args.max_line_width
+  if args.indent_width:
+    style_opts['INDENT_WIDTH'] = args.indent_width
+
   if args.lines and len(args.files) > 1:
     parser.error('cannot use -l/--lines with more than one file')
 
@@ -115,6 +125,7 @@ def main(argv):
         py3compat.unicode('\n'.join(original_source) + '\n'),
         filename='<stdin>',
         style_config=args.style,
+        style_opts=style_opts,
         lines=lines,
         verify=args.verify))
     return 0
@@ -124,6 +135,7 @@ def main(argv):
     raise YapfError('Input filenames did not match any python files')
   FormatFiles(files, lines,
               style_config=args.style,
+              style_opts=style_opts,
               in_place=args.in_place,
               print_diff=args.diff,
               verify=args.verify)
@@ -132,6 +144,7 @@ def main(argv):
 
 def FormatFiles(filenames, lines,
                 style_config=None,
+                style_opts=None,
                 in_place=False,
                 print_diff=False,
                 verify=True):
@@ -144,6 +157,7 @@ def FormatFiles(filenames, lines,
       overrides the 'args.lines'. It can be used by third-party code (e.g.,
       IDEs) when reformatting a snippet of code.
     style_config: (string) Style name or file path.
+    style_opts: (dict) Style options overrides.
     in_place: (bool) Modify the files in place.
     print_diff: (bool) Instead of returning the reformatted source, return a
       diff that turns the formatted source into reformatter source.
@@ -153,6 +167,7 @@ def FormatFiles(filenames, lines,
     logging.info('Reformatting %s', filename)
     reformatted_code = yapf_api.FormatFile(filename,
                                            style_config=style_config,
+                                           style_opts=style_opts,
                                            lines=lines,
                                            print_diff=print_diff,
                                            verify=verify)

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -177,7 +177,7 @@ _STYLE_OPTION_VALUE_CONVERTER = dict(
 )
 
 
-def CreateStyleFromConfig(style_config):
+def CreateStyleFromConfig(style_config, style_opts=None):
   """Create a style dict from the given config.
 
   Arguments:
@@ -186,6 +186,7 @@ def CreateStyleFromConfig(style_config):
       style which it derives from. If no such setting is found, it derives from
       the default style. When style_config is None, the DEFAULT_STYLE_FACTORY
       config is created.
+    style_opts: dictionary of style overrides.
 
   Returns:
     A style dict.
@@ -194,17 +195,26 @@ def CreateStyleFromConfig(style_config):
     StyleConfigError: if an unknown style option was encountered.
   """
   if style_config is None:
-    return DEFAULT_STYLE_FACTORY()
+    style = DEFAULT_STYLE_FACTORY()
+    if style_opts:
+      style.update(style_opts)
+    return style
   style_factory = _STYLE_NAME_TO_FACTORY.get(style_config.lower())
   if style_factory is not None:
-    return style_factory()
+    style = style_factory()
+    if style_opts:
+      style.update(style_opts)
+    return style
   if style_config.startswith('{'):
     # Most likely a style specification from the command line.
     config = _CreateConfigParserFromConfigString(style_config)
   else:
     # Unknown config name: assume it's a file name then.
     config = _CreateConfigParserFromConfigFile(style_config)
-  return _CreateStyleFromConfigParser(config)
+  style = _CreateStyleFromConfigParser(config)
+  if style_opts:
+    style.update(style_opts)
+  return style
 
 
 def _CreateConfigParserFromConfigString(config_string):

--- a/yapf/yapflib/yapf_api.py
+++ b/yapf/yapflib/yapf_api.py
@@ -23,6 +23,7 @@ These APIs have some common arguments:
   style_config: (string) Either a style name or a path to a file that contains
     formatting style settings. If None is specified, use the default style
     as set in style.DEFAULT_STYLE_FACTORY
+  style_opts: (dict) Dictionary of style overrides.
   lines: (list of tuples of integers) A list of tuples of lines, [start, end],
     that we want to format. The lines are 1-based indexed. It can be used by
     third-party code (e.g., IDEs) when reformatting a snippet of code rather
@@ -51,6 +52,7 @@ from yapf.yapflib import subtype_assigner
 
 def FormatFile(filename,
                style_config=None,
+               style_opts=None,
                lines=None,
                print_diff=False,
                verify=True):
@@ -70,6 +72,7 @@ def FormatFile(filename,
 
   return FormatCode(original_source,
                     style_config=style_config,
+                    style_opts=style_opts,
                     filename=filename,
                     lines=lines,
                     print_diff=print_diff,
@@ -79,6 +82,7 @@ def FormatFile(filename,
 def FormatCode(unformatted_source,
                filename='<unknown>',
                style_config=None,
+               style_opts=None,
                lines=None,
                print_diff=False,
                verify=True):
@@ -95,7 +99,7 @@ def FormatCode(unformatted_source,
     The code reformatted to conform to the desired formatting style.
   """
   _CheckPythonVersion()
-  style.SetGlobalStyle(style.CreateStyleFromConfig(style_config))
+  style.SetGlobalStyle(style.CreateStyleFromConfig(style_config, style_opts))
   if not unformatted_source.endswith('\n'):
     unformatted_source += '\n'
   tree = pytree_utils.ParseCodeToTree(unformatted_source)

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -157,6 +157,26 @@ class CommandLineTest(unittest.TestCase):
     self.assertIsNone(stderrdata)
     self.assertEqual(reformatted_code.decode('utf-8'), expected_formatted_code)
 
+  def testSetIndentWidth(self):
+    unformatted_code = textwrap.dedent(u"""\
+        def foo(): # trail
+            x = 37
+        """)
+    expected_formatted_code = textwrap.dedent(u"""\
+        def foo():  # trail
+           x = 37
+        """)
+
+    p = subprocess.Popen(YAPF_BINARY + ['--indent-width=3'],
+                         stdout=subprocess.PIPE,
+                         stdin=subprocess.PIPE,
+                         stderr=subprocess.STDOUT)
+    reformatted_code, stderrdata = p.communicate(
+        unformatted_code.encode('utf-8'))
+    self.assertIsNone(stderrdata)
+    self.assertEqual(reformatted_code.decode('utf-8'), expected_formatted_code)
+
+
   def testSetCustomStyleBasedOnYapf(self):
     unformatted_code = textwrap.dedent(u"""\
         def foo(): # trail
@@ -491,9 +511,9 @@ class CommandLineTest(unittest.TestCase):
 
 
 
-        #comment  
+        #comment
 
-        #   trailing whitespace    
+        #   trailing whitespace
         """)
     expected_formatted_code = textwrap.dedent(u"""\
         if a: b
@@ -508,7 +528,7 @@ class CommandLineTest(unittest.TestCase):
 
         #comment
 
-        #   trailing whitespace    
+        #   trailing whitespace
         """)
 
     p = subprocess.Popen(YAPF_BINARY + ['--lines', '3-3', '--lines', '13-13'],


### PR DESCRIPTION
I know `--style` supports dictionary overrides, but it's pretty unintuitive. Adding line-width as a first-class commandline option matches pep8 the linter. Indent width was easy to add so I did that too, but can remove if you prefer.

PS, these options have a few synonyms. "line width", "column width", "line length" are all in use, as is "indent size" and "indent width". I picked names that seemed to match yapf codebase, but they are different to eg pep8 the linter.