### PR TITLE
Local config search

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[style]
+based_on_style = yapf

--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -91,6 +91,9 @@ def main(argv):
     print('yapf {}'.format(__version__))
     return 0
 
+  if args.style[:5].lower() == 'local':
+    args.style = yapf_api.style.SearchForLocalConfig(args.files)
+
   if args.lines and len(args.files) > 1:
     parser.error('cannot use -l/--lines with more than one file')
 
@@ -149,6 +152,7 @@ def FormatFiles(filenames, lines,
       diff that turns the formatted source into reformatter source.
     verify: (bool) True if reformatted code should be verified for syntax.
   """
+  # TODO do style_config magic just once
   for filename in filenames:
     logging.info('Reformatting %s', filename)
     reformatted_code = yapf_api.FormatFile(filename,

--- a/yapftests/style_test.py
+++ b/yapftests/style_test.py
@@ -71,6 +71,12 @@ class PredefinedStylesByNameTest(unittest.TestCase):
       cfg = style.CreateStyleFromConfig(pep8_name)
       self.assertTrue(_LooksLikePEP8Style(cfg))
 
+  def testLocalByName(self):
+    # NOTE: this tests assumes that style.cfg includes based_on_style yapf
+    for local_name in ('LOCAL', 'local', 'Local'):
+      cfg = style.SearchForLocalConfig(__file__)
+      self.assertTrue(_LooksLikeYapfStyle(cfg))
+
 
 @contextlib.contextmanager
 def _TempFileContents(dirname, contents):


### PR DESCRIPTION
If you pass --style=local, then look up the project's config file.

This replicates the (local) behaviour of pep8/autopep8, global could work similar but I really dislike that... Note: in those libraries it is actually the default behaviour (to apply global and local configs before pep8ing).

Happy to add a bit more documentation if this was considered, or update with a different API.

cc #93