### PR TITLE
remove py32 and py33 from supported versions in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,6 @@ with codecs.open('README.rst', 'r', 'utf-8') as fd:
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.2',
-          'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
           'Topic :: Software Development :: Libraries :: Python Modules',
           'Topic :: Software Development :: Quality Assurance',


### PR DESCRIPTION
cc #104. These versions are not supported so yapf shouldn't use them as classifiers.