### PR TITLE
Have travis actually report a failure if the tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - pip install --quiet coveralls
 
 script:
-  coverage run --source=yapf setup.py test
+  - nosetests --with-coverage --cover-package=yapf
 
 after_success:
-  coveralls
+  - coveralls

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@
 import codecs
 import unittest
 from setuptools import setup, Command
+import sys
 
 import yapf
 import yapftests
@@ -34,7 +35,8 @@ class RunTests(Command):
     loader = unittest.TestLoader()
     tests = loader.discover('yapftests', pattern='*_test.py', top_level_dir='.')
     runner = unittest.TextTestRunner()
-    runner.run(tests)
+    results = runner.run(tests)
+    sys.exit(0 if results.wasSuccessful() else 1)
 
 
 with codecs.open('README.rst', 'r', 'utf-8') as fd:


### PR DESCRIPTION
Currently, `setup.py test` fails it still exits with exit code with 0, and the travis test suite would report a [success](https://travis-ci.org/hayd/yapf/jobs/58862642) (!). Let's not do that.

This can be done in two ways:

- use a testing framework (nose/py.test are preinstalled on travis)
- return a bad exit code if the tests fail.

This does both.