### PR TITLE
Resolving the issue #89: A line can be split between unary operator `not` and its operand 

### DIFF
--- a/yapf/yapflib/unwrapped_line.py
+++ b/yapf/yapflib/unwrapped_line.py
@@ -383,8 +383,10 @@ _TERM_OPERATORS = frozenset({'*', '/', '%', '//'})
 
 def _SplitPenalty(prev_token, cur_token):
   """Return the penalty for breaking the line before the current token."""
-  if cur_token.node_split_penalty > 0:
-    return cur_token.node_split_penalty
+
+  if prev_token.value == 'not' and (cur_token.value == 'True'
+    or cur_token.value == 'False'):
+    return split_penalty.STRONGLY_CONNECTED
 
   if style.Get('SPLIT_BEFORE_LOGICAL_OPERATOR'):
     # Prefer to split before 'and' and 'or'.

--- a/yapftests/split_operator_not.py
+++ b/yapftests/split_operator_not.py
@@ -1,0 +1,63 @@
+import sys
+import textwrap
+import unittest
+
+from yapf.yapflib import blank_line_calculator
+from yapf.yapflib import comment_splicer
+from yapf.yapflib import continuation_splicer
+from yapf.yapflib import pytree_unwrapper
+from yapf.yapflib import pytree_utils
+from yapf.yapflib import pytree_visitor
+from yapf.yapflib import reformatter
+from yapf.yapflib import split_penalty
+from yapf.yapflib import subtype_assigner
+
+
+class TestingNotInParameters(unittest.TestCase):
+
+    def test_notInParams(self):
+        code = textwrap.dedent("""\
+            def sum(a, sprint):
+                return a
+
+
+            sum("felipe barreto volpone longo nome para quebrar porque anda nao q",
+                not True)
+        """)
+        uwlines = _ParseAndUnwrap(code)
+        self.assertEqual(code, reformatter.Reformat(uwlines))
+
+
+def _ParseAndUnwrap(code, dumptree=False):
+  """Produces unwrapped lines from the given code.
+
+  Parses the code into a tree, performs comment splicing and runs the
+  unwrapper.
+
+  Arguments:
+    code: code to parse as a string
+    dumptree: if True, the parsed pytree (after comment splicing) is dumped
+              to stderr. Useful for debugging.
+
+  Returns:
+    List of unwrapped lines.
+  """
+  tree = pytree_utils.ParseCodeToTree(code)
+  comment_splicer.SpliceComments(tree)
+  continuation_splicer.SpliceContinuations(tree)
+  subtype_assigner.AssignSubtypes(tree)
+  split_penalty.ComputeSplitPenalties(tree)
+  blank_line_calculator.CalculateBlankLines(tree)
+
+  if dumptree:
+    pytree_visitor.DumpPyTree(tree, target_stream=sys.stderr)
+
+  uwlines = pytree_unwrapper.UnwrapPyTree(tree)
+  for uwl in uwlines:
+    uwl.CalculateFormattingInformation()
+
+  return uwlines
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
I changed the unwrapped_line._SplitPenalty method to check if the not operator is followed by True or False. Also, I created a test called split_operator_not.py to show the fix. Really thanks to @gwelymernans who helped me to do this.

Tks