### PR TITLE
Add check cli option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,8 @@ Options::
       --style STYLE         specify formatting style: either a style name (for
                             example "pep8" or "google"), or the name of a file
                             with style settings. pep8 is the default.
+      -c, --check           heck the files adhere to the style, exits with
+                            status 3 if not
       -d, --diff            print the diff for the fixed source
       -i, --in-place        make changes to files in place
       -l START-END, --lines START-END

--- a/yapf/yapflib/yapf_api.py
+++ b/yapf/yapflib/yapf_api.py
@@ -119,7 +119,7 @@ def FormatCode(unformatted_source,
   reformatted_source = reformatter.Reformat(uwlines, verify)
 
   if unformatted_source == reformatted_source:
-    return '' if print_diff else reformatted_source
+    return None if print_diff else reformatted_source
 
   code_diff = _GetUnifiedDiff(unformatted_source, reformatted_source,
                               filename=filename)

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -34,9 +34,11 @@ YAPF_BINARY = [sys.executable, '-m', 'yapf', '--verify']
 
 class YapfTest(unittest.TestCase):
 
-  def _Check(self, unformatted_code, expected_formatted_code):
+  def _Check(self, unformatted_code, expected_formatted_code,
+             print_diff=False):
     style.SetGlobalStyle(style.CreateChromiumStyle())
-    formatted_code = yapf_api.FormatCode(unformatted_code)
+    formatted_code = yapf_api.FormatCode(unformatted_code,
+                                         print_diff=print_diff)
     self.assertEqual(expected_formatted_code, formatted_code)
 
   def testSimple(self):
@@ -52,6 +54,22 @@ class YapfTest(unittest.TestCase):
         if True: pass
         """)
     self._Check(unformatted_code, expected_formatted_code)
+
+  def testPrintDiffButThereIsNoDifference(self):
+      unformatted_code = u'a = 1\n'
+      expected_diff = None
+      self._Check(unformatted_code, expected_diff, print_diff=True)
+
+  def testPrintDiffAndThereIsADifference(self):
+      unformatted_code = u'a    =    1'
+      expected_diff = textwrap.dedent(u"""\
+          --- <unknown>\t(original)
+          +++ <unknown>\t(reformatted)
+          @@ -1 +1 @@
+          -a    =    1
+          +a = 1
+          """)
+      self._Check(unformatted_code, expected_diff, print_diff=True)
 
 
 class CommandLineTest(unittest.TestCase):

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -645,6 +645,81 @@ class CommandLineTest(unittest.TestCase):
     self.assertIsNone(stderrdata)
     self.assertEqual(reformatted_code.decode('utf-8'), expected_formatted_code)
 
+  def testCheckOutputCodeWhenCodeDoesMeetStyle(self):
+    unformatted_code = u'a = 1\n'
+    expected_diff = u''
+
+    with tempfile.NamedTemporaryFile(suffix='.py',
+                                     dir=self.test_tmpdir) as testfile:
+      testfile.write(unformatted_code.encode('utf-8'))
+      testfile.seek(0)
+      p = subprocess.Popen(YAPF_BINARY + ['--check', testfile.name],
+                       stdout=subprocess.PIPE,
+                       stderr=subprocess.STDOUT)
+      diff, stderrdata = p.communicate(
+          unformatted_code.encode('utf-8'))
+
+      self.assertEqual(diff.decode('utf-8'), expected_diff)
+      self.assertIsNone(stderrdata)
+
+  def testCheckExitStatusWhenCodeAlreadyMeetsStyle(self):
+    unformatted_code = u'a = 1\n'
+
+    with tempfile.NamedTemporaryFile(suffix='.py',
+                                     dir=self.test_tmpdir) as outfile:
+      with tempfile.NamedTemporaryFile(suffix='.py',
+                                       dir=self.test_tmpdir) as testfile:
+        testfile.write(unformatted_code.encode('utf-8'))
+        testfile.seek(0)
+        subprocess.check_call(YAPF_BINARY + ['--check', testfile.name],
+                              stdout=outfile)
+
+  def testCheckOutputWhenCodeDoesNotMeetStyle(self):
+    unformatted_code = u'a    =     1'
+
+    with tempfile.NamedTemporaryFile(suffix='.py',
+                                     dir=self.test_tmpdir) as testfile:
+
+      expected_diff = (u'--- {}\t(original)\n+++ {}\t(reformatted)\n@@ -1 +1 '
+                        '@@\n-a    =     1\n+a = 1\n'.format(testfile.name,
+                                                             testfile.name))
+
+      testfile.write(unformatted_code.encode('utf-8'))
+      testfile.seek(0)
+      p = subprocess.Popen(YAPF_BINARY + ['--check', testfile.name],
+                       stdout=subprocess.PIPE,
+                       stderr=subprocess.STDOUT)
+      diff, stderrdata = p.communicate(
+          unformatted_code.encode('utf-8'))
+
+      self.assertEqual(diff.decode('utf-8'), expected_diff)
+      self.assertIsNone(stderrdata)
+
+  def testCheckExitStatusWhenCodeDoesNotMeetStyle(self):
+    unformatted_code = u'a    =     1'
+
+    with tempfile.NamedTemporaryFile(suffix='.py',
+                                     dir=self.test_tmpdir) as outfile:
+      with tempfile.NamedTemporaryFile(suffix='.py',
+                                       dir=self.test_tmpdir) as testfile:
+        testfile.write(unformatted_code.encode('utf-8'))
+        testfile.seek(0)
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+          subprocess.check_call(YAPF_BINARY + ['--check', testfile.name],
+                                stdout=outfile)
+
+        self.assertEqual(cm.exception.returncode, 3)
+
+  def testCheckFlagCannotBeUsedWithSTDIN(self):
+    p = subprocess.Popen(YAPF_BINARY + ['--check'],
+                         stdout=subprocess.PIPE,
+                         stdin=subprocess.PIPE,
+                         stderr=subprocess.STDOUT)
+    with self.assertRaises(subprocess.CalledProcessError) as cm:
+      subprocess.check_call(YAPF_BINARY + ['--check'])
+
+    self.assertEqual(cm.exception.returncode, 2)
+
 
 class BadInputTest(unittest.TestCase):
   """Test yapf's behaviour when passed bad input."""


### PR DESCRIPTION
The --check option determines if the given files adhere to the specified style or not. If none of the files require reformatting it will exit normally and log nothing to STDOUT. If reformatting is required to meet the standard then it will print the diff and exit with status 3.

A couple of things I should note:

1. This prints the diffs of files that need reformatting (if there are any), as such there's a certain amount of overlap with the --diff option. Maybe it should output something different, like the out-of-style file paths?
2. I chose exit status 3 relatively arbitrarily, it's the first non-reserved exit status
3. I have not formatted the code, I ran `yapf --style chromium --diff -r .` before I started working on this and noticed some files that need formatting, I thought I'd keep the diff small :)