### PR TITLE
Don't print backtraces for user/input errors

### DIFF
--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -32,16 +32,13 @@ import logging
 import os
 import sys
 
+from yapf.yapflib import errors
 from yapf.yapflib import file_resources
 from yapf.yapflib import py3compat
 from yapf.yapflib import style
 from yapf.yapflib import yapf_api
 
 __version__ = '0.1.7'
-
-
-class YapfError(Exception):
-  pass
 
 
 def main(argv):
@@ -147,7 +144,7 @@ def main(argv):
 
   files = file_resources.GetCommandLineFiles(args.files, args.recursive)
   if not files:
-    raise YapfError('Input filenames did not match any python files')
+    raise errors.YapfError('Input filenames did not match any python files')
   FormatFiles(files, lines,
               style_config=args.style,
               no_local_style=args.no_local_style,
@@ -213,15 +210,19 @@ def _GetLines(line_strings):
     # The 'list' here is needed by Python 3.
     line = list(map(int, line_string.split('-', 1)))
     if line[0] < 1:
-      raise ValueError('invalid start of line range: %r' % line)
+      raise errors.YapfError('invalid start of line range: %r' % line)
     if line[0] > line[1]:
-      raise ValueError('end comes before start in line range: %r', line)
+      raise errors.YapfError('end comes before start in line range: %r', line)
     lines.append(tuple(line))
   return lines
 
 
 def run_main():  # pylint: disable=invalid-name
-  sys.exit(main(sys.argv))
+  try:
+    sys.exit(main(sys.argv))
+  except errors.YapfError as e:
+    sys.stderr.write('yapf: ' + str(e) + '\n')
+    sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/yapf/yapflib/errors.py
+++ b/yapf/yapflib/errors.py
@@ -12,3 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+class YapfError(Exception):
+  """Parent class for user errors or input errors.
+
+  Exceptions of this type are handled by the command line tool
+  and result in clear error messages, as opposed to backtraces.
+  """
+  pass

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -18,13 +18,10 @@ import re
 import textwrap
 
 from yapf.yapflib import py3compat
+from yapf.yapflib import errors
 
 
-class Error(Exception):
-  pass
-
-
-class StyleConfigError(Error):
+class StyleConfigError(errors.YapfError):
   """Raised when there's a problem reading the style configuration."""
   pass
 

--- a/yapftests/main_test.py
+++ b/yapftests/main_test.py
@@ -57,10 +57,23 @@ def patched_input(code):
     yapf.py3compat.raw_input = raw_input
 
 
+class RunMainTest(unittest.TestCase):
+
+  def testShouldHandleYapfError(self):
+    """run_main should handle YapfError and sys.exit(1)"""
+    expected_message = 'yapf: Input filenames did not match any python files\n'
+    sys.argv = ['yapf', 'foo.c']
+    with captured_output() as (out, err):
+      with self.assertRaises(SystemExit):
+        ret = yapf.run_main()
+      self.assertEqual(out.getvalue(), '')
+      self.assertEqual(err.getvalue(), expected_message)
+
+
 class MainTest(unittest.TestCase):
 
   def testNoPythonFilesMatched(self):
-    with self.assertRaisesRegexp(yapf.YapfError,
+    with self.assertRaisesRegexp(yapf.errors.YapfError,
                                  'did not match any python files'):
       yapf.main(['yapf', 'foo.c'])
 


### PR DESCRIPTION
This change introduces a common YapfError parent class
that can be used for input/user error.  run_main() then
handles these errors and prints a nice error message
rather than a nasty backtrace (backtraces IMHO should
only be printed for program errors).

Fixes #130