### PR TITLE
Add argument `--stdout-encoding`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,6 +94,8 @@ Options::
                             directories of the source file (or current directory
                             for stdin)
       --verify              try to verify refomatted code for syntax errors
+      --stdout-encoding STDOUT_ENCODING
+                            define stdout encoding
       -d, --diff            print the diff for the fixed source
       -i, --in-place        make changes to files in place
       -l START-END, --lines START-END

--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -76,6 +76,11 @@ def main(argv):
   parser.add_argument('--verify',
                       action='store_true',
                       help='try to verify reformatted code for syntax errors')
+
+  parser.add_argument('--stdout-encoding',
+                      action='store',
+                      help='define stdout encoding')
+
   diff_inplace_group = parser.add_mutually_exclusive_group()
   diff_inplace_group.add_argument('-d', '--diff',
                                   action='store_true',
@@ -121,6 +126,7 @@ def main(argv):
       parser.error('cannot use --in_place or --diff flags when reading '
                    'from stdin')
 
+
     original_source = []
     while True:
       try:
@@ -134,12 +140,19 @@ def main(argv):
     style_config = args.style
     if style_config is None and not args.no_local_style:
       style_config = file_resources.GetDefaultStyleForDir(os.getcwd())
-    sys.stdout.write(yapf_api.FormatCode(
-        py3compat.unicode('\n'.join(original_source) + '\n'),
-        filename='<stdin>',
-        style_config=style_config,
-        lines=lines,
-        verify=args.verify))
+
+    formatedCode = yapf_api.FormatCode(
+                        py3compat.unicode('\n'.join(original_source) + '\n'),
+                        filename='<stdin>',
+                        style_config=style_config,
+                        lines=lines,
+                        verify=args.verify)
+
+    if not args.stdout_encoding:
+        sys.stdout.write(formatedCode)
+    else:
+        sys.stdout.write(formatedCode.encode(args.stdout_encoding))
+
     return 0
 
   files = file_resources.GetCommandLineFiles(args.files, args.recursive)


### PR DESCRIPTION
When use yapf to format code from stdin

Cannot choose the stdout encoding(my stdout encoding is `utf-8`), and then
```
#!/usr/bin/env python
# encoding: utf-8

# 中文
```

the plugins which use `yapf` 
will case error

```
Traceback (most recent call last):
  File "/usr/local/bin/yapf", line 11, in <module>
    sys.exit(run_main())
  File "/usr/local/lib/python2.7/site-packages/yapf/__init__.py", line 222, in run_main
    sys.exit(main(sys.argv))
  File "/usr/local/lib/python2.7/site-packages/yapf/__init__.py", line 142, in main
    verify=args.verify))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 43-44: ordinal not in range(128)
```


