### PR TITLE
stdin encoding detect

### DIFF
--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -31,6 +31,8 @@ import argparse
 import logging
 import os
 import sys
+import codecs
+import locale
 
 from yapf.yapflib import errors
 from yapf.yapflib import file_resources
@@ -121,6 +123,8 @@ def main(argv):
       parser.error('cannot use --in_place or --diff flags when reading '
                    'from stdin')
 
+    lang, encoding = locale.getdefaultlocale()
+    sys.stdin = codecs.getreader(encoding)(sys.stdin)
     original_source = []
     while True:
       try:
@@ -134,12 +138,13 @@ def main(argv):
     style_config = args.style
     if style_config is None and not args.no_local_style:
       style_config = file_resources.GetDefaultStyleForDir(os.getcwd())
-    sys.stdout.write(yapf_api.FormatCode(
-        py3compat.unicode('\n'.join(original_source) + '\n'),
-        filename='<stdin>',
-        style_config=style_config,
-        lines=lines,
-        verify=args.verify))
+    formatedCode = yapf_api.FormatCode(
+                        '\n'.join(original_source) + '\n',
+                        filename='<stdin>',
+                        style_config=style_config,
+                        lines=lines,
+                        verify=args.verify)
+    py3compat.EncodeAndWriteToStdout(formatedCode, encoding)
     return 0
 
   files = file_resources.GetCommandLineFiles(args.files, args.recursive)


### PR DESCRIPTION
fix Error `UnicodeEncodeError` where stdin encoding is not `utf-8`

```
Traceback (most recent call last):
  File "/usr/local/bin/yapf", line 11, in <module>
    sys.exit(run_main())
  File "/usr/local/lib/python2.7/site-packages/yapf/__init__.py", line 222, in run_main
    sys.exit(main(sys.argv))
  File "/usr/local/lib/python2.7/site-packages/yapf/__init__.py", line 142, in main
    verify=args.verify))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 43-44: ordinal not in range(128)
```

-------------

the pre closed pr is https://github.com/google/yapf/pull/136

I just change the stdin reading

```
sys.stdin = codecs.getreader(encoding)(sys.stdin)
```

and add a testcase.

I have run nosetests in serval different `locale` settings, all passed.