### PR TITLE
fix for infinite loop on style file search on windows

### DIFF
--- a/yapf/yapflib/file_resources.py
+++ b/yapf/yapflib/file_resources.py
@@ -43,7 +43,7 @@ def GetDefaultStyleForDir(dirname):
     if os.path.exists(style_file):
       return style_file
     dirname = os.path.dirname(dirname)
-    if not dirname or dirname == os.path.sep:
+    if not dirname or dirname == os.path.abspath(os.path.sep):
       break
 
   return style.DEFAULT_STYLE


### PR DESCRIPTION
`os.path.dirname('C:\\')` returns `'C:\\'` on windows system, not the widows path separator `'\\'`. This prevents the break from being called and creates an infinite loop on windows file systems if there is no style file in any parent directory, making yapf hang indefinitely.

Calling `os.path.abspath(os.path.sep)` returns `'/'` on posix systems and `'C:\\'` or whatever drive letter you're on for windows systems. 

Quick `abspath` in the break-case check fixes the infinite loop.