### PR TITLE
DOC: Use a valid literal in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -279,9 +279,9 @@ You can also disable formatting for a single literal like this:
 .. code-block:: python
 
     BAZ = {
-        [1, 2, 3, 4],
-        [5, 6, 7, 8],
-        [9, 10, 11, 12]
+        (1, 2, 3, 4),
+        (5, 6, 7, 8),
+        (9, 10, 11, 12),
     }  # yapf: disable
 
 Why Not Improve Existing Tools?


### PR DESCRIPTION
Switch example from using a set of lists (which is invalid because python lists are mutable and hence not hashable) to a set of tuples.