### PR TITLE
Detect gyp files as python files

### DIFF
--- a/yapf/yapflib/file_resources.py
+++ b/yapf/yapflib/file_resources.py
@@ -98,7 +98,7 @@ def _FindPythonFiles(filenames, recursive):
 
 def IsPythonFile(filename):
   """Return True if filename is a Python file."""
-  if os.path.splitext(filename)[1] == '.py':
+  if os.path.splitext(filename)[1] in ['.py', '.gyp', '.gypi']:
     return True
 
   try:

--- a/yapftests/file_resources_test.py
+++ b/yapftests/file_resources_test.py
@@ -132,6 +132,12 @@ class IsPythonFileTest(unittest.TestCase):
     file1 = os.path.join(self.test_tmpdir, 'testfile1.py')
     self.assertTrue(file_resources.IsPythonFile(file1))
 
+  def test_with_gyp_extenstion(self):
+    file1 = os.path.join(self.test_tmpdir, 'testfile1.gyp')
+    self.assertTrue(file_resources.IsPythonFile(file1))
+    file1 = os.path.join(self.test_tmpdir, 'testfile1.gypi')
+    self.assertTrue(file_resources.IsPythonFile(file1))
+
   def test_empty_without_py_extension(self):
     file1 = os.path.join(self.test_tmpdir, 'testfile1')
     self.assertFalse(file_resources.IsPythonFile(file1))


### PR DESCRIPTION
Gyp file syntax is purely a subset of python's so it makes sense to use YAPF to reformat them too.
