### PR TITLE
Fix formatting of multiple files

### DIFF
--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -198,7 +198,7 @@ def FormatFiles(filenames, lines,
     if reformatted_code is not None:
       file_resources.WriteReformattedCode(filename, reformatted_code, in_place,
                                           encoding)
-    return changed
+  return changed
 
 
 def _GetLines(line_strings):


### PR DESCRIPTION
FormatFiles was returning after formatting the first file, even if multiple files were provided.