### PR TITLE
Update Readme to use correct filename for local style

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,7 +150,7 @@ indentations.
 YAPF will search for the formatting style in the following manner:
 
 1. Specified on the command line
-2. In the `[style]` section of a `.yapf.style` file in either the current
+2. In the `[style]` section of a `.style.yapf` file in either the current
    directory or one of its parent directories.
 3. In the `[yapf]` secionf of a `setup.cfg` file in either the current
    directory or one of its parent directories.


### PR DESCRIPTION
According to https://github.com/google/yapf/blob/master/yapf/yapflib/style.py#L368 the filename in the readme is incorrect. This simply changes it to use the correct filename.