### PR TITLE
Support for formatting partial blocks of codes.

### DIFF
--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -212,13 +212,13 @@ def FormatFiles(filenames,
           print_diff=print_diff,
           verify=verify,
           logger=logging.warning)
+      if reformatted_code is not None:
+        file_resources.WriteReformattedCode(filename, reformatted_code, in_place,
+                                            encoding)
       changed |= has_change
     except SyntaxError as e:
       e.filename = filename
       raise
-    if reformatted_code is not None:
-      file_resources.WriteReformattedCode(filename, reformatted_code, in_place,
-                                          encoding)
   return changed
 
 

--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -37,7 +37,7 @@ from yapf.yapflib import py3compat
 from yapf.yapflib import style
 from yapf.yapflib import yapf_api
 
-__version__ = '0.6.3'
+__version__ = '0.7.1'
 
 
 import sys

--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -30,12 +30,6 @@ from __future__ import print_function
 import argparse
 import logging
 import os
-from re import match
-
-try:
-    from textwrap import dedent, indent
-except ImportError:
-    from py3compat import indent
 
 from yapf.yapflib import errors
 from yapf.yapflib import file_resources
@@ -152,24 +146,17 @@ def main(argv):
         break
 
     original_source.append('')
-    text_to_format = '\n'.join(original_source)
-    indent_match = match('^(\s+)', original_source[0])
-    if indent_match:
-        text_to_format = dedent(text_to_format)
-
     style_config = args.style
     if style_config is None and not args.no_local_style:
       style_config = file_resources.GetDefaultStyleForDir(os.getcwd())
     reformatted_source, changed = yapf_api.FormatCode(
-        py3compat.unicode(text_to_format),
+        py3compat.unicode('\n'.join(original_source)),
         filename='<stdin>',
         style_config=style_config,
         lines=lines,
         verify=args.verify)
     out = reformatted_source
-    if indent_match:
-        out = indent(out, indent_match.group(0))
-    sys.stdout.write(out)
+    sys.stdout.write(reformatted_source)
     return 2 if changed else 0
 
   files = file_resources.GetCommandLineFiles(args.files, args.recursive,

--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -41,7 +41,6 @@ from yapf.yapflib import yapf_api
 __version__ = '0.7.1'
 
 
-
 def main(argv):
   """Main program.
 

--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -30,6 +30,7 @@ from __future__ import print_function
 import argparse
 import logging
 import os
+import sys
 
 from yapf.yapflib import errors
 from yapf.yapflib import file_resources
@@ -40,7 +41,6 @@ from yapf.yapflib import yapf_api
 __version__ = '0.7.1'
 
 
-import sys
 
 def main(argv):
   """Main program.
@@ -155,7 +155,6 @@ def main(argv):
         style_config=style_config,
         lines=lines,
         verify=args.verify)
-    out = reformatted_source
     sys.stdout.write(reformatted_source)
     return 2 if changed else 0
 

--- a/yapf/yapflib/py3compat.py
+++ b/yapf/yapflib/py3compat.py
@@ -83,3 +83,7 @@ class ConfigParser(configparser.ConfigParser):
 
     def read_file(self, fp, source=None):
       self.readfp(fp, filename=source)
+
+
+def indent(text, indent):
+    return '\n'.join(indent + l for l in text.split('\n')[:-1])

--- a/yapf/yapflib/py3compat.py
+++ b/yapf/yapflib/py3compat.py
@@ -86,4 +86,4 @@ class ConfigParser(configparser.ConfigParser):
 
 
 def indent(text, indent):
-    return ('\n' + indent).join(l for l in text.split('\n')[:-1])
+    return '\n'.join(indent + l for l in text.split('\n')[:-1])

--- a/yapf/yapflib/py3compat.py
+++ b/yapf/yapflib/py3compat.py
@@ -86,4 +86,4 @@ class ConfigParser(configparser.ConfigParser):
 
 
 def indent(text, indent):
-    return '\n'.join(indent + l for l in text.split('\n')[:-1])
+    return ('\n' + indent).join(l for l in text.split('\n')[:-1])

--- a/yapf/yapflib/yapf_api.py
+++ b/yapf/yapflib/yapf_api.py
@@ -50,6 +50,11 @@ from yapf.yapflib import split_penalty
 from yapf.yapflib import style
 from yapf.yapflib import subtype_assigner
 
+try:
+    from textwrap import dedent, indent
+except ImportError:
+    indent = py3compat.indent
+
 
 def FormatFile(filename,
                style_config=None,
@@ -119,6 +124,12 @@ def FormatCode(unformatted_source,
   style.SetGlobalStyle(style.CreateStyleFromConfig(style_config))
   if not unformatted_source.endswith('\n'):
     unformatted_source += '\n'
+
+  fst_newline = unformatted_source.find('\n')
+
+  indent_match = re.match('^(\s+)', unformatted_source[:fst_newline])
+  if indent_match:
+    unformatted_source = dedent(unformatted_source)
   tree = pytree_utils.ParseCodeToTree(unformatted_source)
 
   # Run passes on the tree, modifying it in place.
@@ -134,6 +145,8 @@ def FormatCode(unformatted_source,
 
   _MarkLinesToFormat(uwlines, lines)
   reformatted_source = reformatter.Reformat(uwlines, verify)
+  if indent_match:
+    reformatted_source = indent(reformatted_source, indent_match.group(0))
 
   if unformatted_source == reformatted_source:
     return '' if print_diff else reformatted_source, False

--- a/yapf/yapflib/yapf_api.py
+++ b/yapf/yapflib/yapf_api.py
@@ -146,7 +146,10 @@ def FormatCode(unformatted_source,
   _MarkLinesToFormat(uwlines, lines)
   reformatted_source = reformatter.Reformat(uwlines, verify)
   if indent_match:
-    reformatted_source = indent(reformatted_source, indent_match.group(0))
+    original_indent = indent_match.group(0)
+    offset = len(original_indent) % 4
+    probable_indent = original_indent[:-offset]
+    reformatted_source = indent(reformatted_source, probable_indent)
 
   if unformatted_source == reformatted_source:
     return '' if print_diff else reformatted_source, False

--- a/yapf/yapflib/yapf_api.py
+++ b/yapf/yapflib/yapf_api.py
@@ -121,15 +121,21 @@ def FormatCode(unformatted_source,
     desired formatting style. changed is True if the source changed.
   """
   _CheckPythonVersion()
-  style.SetGlobalStyle(style.CreateStyleFromConfig(style_config))
   if not unformatted_source.endswith('\n'):
     unformatted_source += '\n'
 
   fst_newline = unformatted_source.find('\n')
 
   indent_match = re.match('^(\s+)', unformatted_source[:fst_newline])
+  st = style.CreateStyleFromConfig(style_config)
   if indent_match:
     unformatted_source = dedent(unformatted_source)
+    original_indent = indent_match.group(0)
+    original_len = len(original_indent)
+    offset = original_len - original_len % 4
+    probable_indent = original_indent[:offset]
+    st['COLUMN_LIMIT'] -= len(probable_indent)
+  style.SetGlobalStyle(st)
   tree = pytree_utils.ParseCodeToTree(unformatted_source)
 
   # Run passes on the tree, modifying it in place.

--- a/yapf/yapflib/yapf_api.py
+++ b/yapf/yapflib/yapf_api.py
@@ -132,7 +132,7 @@ def FormatCode(unformatted_source,
     unformatted_source = dedent(unformatted_source)
     original_indent = indent_match.group(0)
     original_len = len(original_indent)
-    offset = original_len - original_len % 4
+    offset = original_len - original_len % st['INDENT_WIDTH']
     probable_indent = original_indent[:offset]
     st['COLUMN_LIMIT'] -= len(probable_indent)
   style.SetGlobalStyle(st)
@@ -152,10 +152,6 @@ def FormatCode(unformatted_source,
   _MarkLinesToFormat(uwlines, lines)
   reformatted_source = reformatter.Reformat(uwlines, verify)
   if indent_match:
-    original_indent = indent_match.group(0)
-    original_len = len(original_indent)
-    offset = original_len - original_len % 4
-    probable_indent = original_indent[:offset]
     reformatted_source = indent(reformatted_source, probable_indent)
 
   if unformatted_source == reformatted_source:

--- a/yapf/yapflib/yapf_api.py
+++ b/yapf/yapflib/yapf_api.py
@@ -147,8 +147,9 @@ def FormatCode(unformatted_source,
   reformatted_source = reformatter.Reformat(uwlines, verify)
   if indent_match:
     original_indent = indent_match.group(0)
-    offset = len(original_indent) % 4
-    probable_indent = original_indent[:-offset]
+    original_len = len(original_indent)
+    offset = original_len - original_len % 4
+    probable_indent = original_indent[:offset]
     reformatted_source = indent(reformatted_source, probable_indent)
 
   if unformatted_source == reformatted_source:

--- a/yapftests/main_test.py
+++ b/yapftests/main_test.py
@@ -98,7 +98,6 @@ class MainTest(unittest.TestCase):
     bad_syntax = "  a = 1\n"
     with patched_input(bad_syntax):
       with captured_output() as (out, err):
-        with self.assertRaisesRegexp(SyntaxError, "unexpected indent"):
           ret = yapf.main([])
 
   def testHelp(self):

--- a/yapftests/main_test.py
+++ b/yapftests/main_test.py
@@ -65,7 +65,7 @@ class RunMainTest(unittest.TestCase):
     sys.argv = ['yapf', 'foo.c']
     with captured_output() as (out, err):
       with self.assertRaises(SystemExit):
-       ret = yapf.run_main()
+        ret = yapf.run_main()
       self.assertEqual(out.getvalue(), '')
       self.assertEqual(err.getvalue(), expected_message)
 

--- a/yapftests/main_test.py
+++ b/yapftests/main_test.py
@@ -65,7 +65,7 @@ class RunMainTest(unittest.TestCase):
     sys.argv = ['yapf', 'foo.c']
     with captured_output() as (out, err):
       with self.assertRaises(SystemExit):
-        ret = yapf.run_main()
+       ret = yapf.run_main()
       self.assertEqual(out.getvalue(), '')
       self.assertEqual(err.getvalue(), expected_message)
 
@@ -98,7 +98,7 @@ class MainTest(unittest.TestCase):
     bad_syntax = "  a = 1\n"
     with patched_input(bad_syntax):
       with captured_output() as (out, err):
-          ret = yapf.main([])
+        ret = yapf.main([])
 
   def testHelp(self):
     with captured_output() as (out, err):

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -1037,7 +1037,7 @@ class BadInputTest(unittest.TestCase):
 
   def testBadSyntax(self):
     code = '  a = 1\n'
-    self.assertRaises(SyntaxError, yapf_api.FormatCode, code)
+    yapf_api.FormatCode, code
 
 
 if __name__ == '__main__':

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -58,7 +58,7 @@ class FormatCodeTest(unittest.TestCase):
         """)
     self._Check(unformatted_code, expected_formatted_code)
 
-  def testWrongIndent(self):
+def test_wrong_indent():
     code = (
       u'    very_long_variable_name = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)'
     ) 
@@ -66,7 +66,7 @@ class FormatCodeTest(unittest.TestCase):
     very_long_variable_name = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
                                15, 16)"""
     formatted_code, _ = yapf_api.FormatCode(code, style_config='pep8')
-    self.assertEqual(correct_code, formatted_code)
+    assert correct_code == formatted_code
 
 
 class FormatFileTest(unittest.TestCase):
@@ -1054,12 +1054,13 @@ class BadInputTest(unittest.TestCase):
 
 @pytest.mark.parametrize('num_of_spaces, correct_num_of_spaces', (
   (5, 4),
-  (4, 4)
+  (4, 4),
 ))
 def test_wrong_indent(num_of_spaces, correct_num_of_spaces):
   stmt = 'a = 1\n'
   code = ' ' * num_of_spaces + stmt
-  spaces = len(match('^(\s+)', yapf_api.FormatCode(code)[0]).group(0)) 
+  formatted_code, _ = yapf_api.FormatCode(code, style_config='pep8')
+  spaces = len(match('^(\s+)', formatted_code).group(0)
   assert spaces == correct_num_of_spaces
 
 

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -58,6 +58,16 @@ class FormatCodeTest(unittest.TestCase):
         """)
     self._Check(unformatted_code, expected_formatted_code)
 
+  def testWrongIndent(self):
+    code = (
+      u'    very_long_variable_name = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)'
+    ) 
+    correct_code = u"""\
+    very_long_variable_name = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+                               15, 16)"""
+    formatted_code, _ = yapf_api.FormatCode(code, style_config='pep8')
+    self.assertEqual(correct_code, formatted_code)
+
 
 class FormatFileTest(unittest.TestCase):
 

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -15,6 +15,7 @@
 """Tests for yapf.yapf."""
 
 import io
+from re import match
 import logging
 import os
 import shutil
@@ -23,6 +24,7 @@ import sys
 import tempfile
 import textwrap
 import unittest
+import pytest
 
 from yapf.yapflib import py3compat
 from yapf.yapflib import yapf_api
@@ -1037,7 +1039,13 @@ class BadInputTest(unittest.TestCase):
 
   def testBadSyntax(self):
     code = '  a = 1\n'
-    yapf_api.FormatCode, code
+    yapf_api.FormatCode(code)
+
+def test_wrong_indent():
+  num_of_spaces = 5
+  stmt = 'a = 1\n'
+  code = ' ' * num_of_spaces + stmt
+  assert len(match('^(\s+)', yapf_api.FormatCode(code)[0]).group(0)) == 4
 
 
 if __name__ == '__main__':

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -1041,11 +1041,16 @@ class BadInputTest(unittest.TestCase):
     code = '  a = 1\n'
     yapf_api.FormatCode(code)
 
-def test_wrong_indent():
-  num_of_spaces = 5
+
+@pytest.mark.parametrize('num_of_spaces, correct_num_of_spaces', (
+  (5, 4),
+  (4, 4)
+))
+def test_wrong_indent(num_of_spaces, correct_num_of_spaces):
   stmt = 'a = 1\n'
   code = ' ' * num_of_spaces + stmt
-  assert len(match('^(\s+)', yapf_api.FormatCode(code)[0]).group(0)) == 4
+  spaces = len(match('^(\s+)', yapf_api.FormatCode(code)[0]).group(0)) 
+  assert spaces == correct_num_of_spaces
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This as far as I've tested closes [https://github.com/google/yapf/issues/224](#224)
I've ran your tests (changing two of them which were checking formatting of bad input) they all green.
Also I've tested if manually on some inputs and it works fine.
One thing though. If the indentation was incorrect (not a multiple of four etc) yapf wouldn't fix it for partial inputs. Which is actually easy to fix. But me or someone else could add this later.