### PR TITLE
Fix typo in field name

### DIFF
--- a/yapf/yapflib/format_decision_state.py
+++ b/yapf/yapflib/format_decision_state.py
@@ -436,7 +436,7 @@ class FormatDecisionState(object):
       new_indent = style.Get('CONTINUATION_INDENT_WIDTH') + last.last_space
 
       self.stack.append(_ParenState(new_indent, self.stack[-1].last_space))
-      self.stack[-1].break_before_paremeter = False
+      self.stack[-1].split_before_parameter = False
       self.paren_level += 1
 
     # If we encounter a closing bracket, we can remove a level from our


### PR DESCRIPTION
I noticed that `_ParenState` class has no `break_before_paremeter` field. I *guess* that the author meant to use `split_before_parameter`, but no tests detect the change, so perhaps this line can be deleted altogether? Please investigate thoroughly before merging.