### PR TITLE
Travis improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: python
 
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
+  - 2.7
+  - 3.4
+  - 3.5
+  - nightly
+
+matrix:
+  allow_failures:
+    - python: nightly
 
 install:
   - pip install --quiet coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,19 @@ python:
 matrix:
   allow_failures:
     - python: nightly
+  include:
+    - python: 2.7
+      env: SCA=true
+    - python: 3.5
+      env: SCA=true
 
 install:
-  - pip install --quiet coveralls
+  - if [ -z "$SCA" ]; then pip install --quiet coveralls; else echo skip; fi
+  - if [ -n "$SCA" ]; then python setup.py develop; else echo skip; fi
 
 script:
-  - nosetests --with-coverage --cover-package=yapf
+  - if [ -n "$SCA" ]; then yapf --diff --recursive . || exit; else echo skip; fi
+  - if [ -z "$SCA" ]; then nosetests --with-coverage --cover-package=yapf; else echo skip; fi
 
 after_success:
   - coveralls


### PR DESCRIPTION
This will give an advanced warning if yapf would become incompatible with python 3.6 and, most importantly, makes sure that yapf source tree is properly formatted at all times. Lack of this causes reformatting to appear in commits of contributors who run `yapf -i -r .`, which breaks `git blame` and others.