### PR TITLE
Pylint

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -61,6 +61,10 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 disable=
+    # disabled by me,
+    locally-disabled,
+    missing-docstring,
+    fixme,
     # disabled by default,
     import-star-module-level,
     old-octal-literal,
@@ -164,7 +168,7 @@ max-module-lines=1000
 
 # String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
 # tab).
-indent-string='    '
+indent-string='  '
 
 # Number of spaces of indent required inside a hanging  or continued line.
 indent-after-paren=4
@@ -203,7 +207,7 @@ logging-modules=logging
 bad-functions=map,filter,input
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=i,j,k,ex,Run,_
+good-names=i,e,s,_,fd,fp
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,baz,toto,tutu,tata
@@ -216,7 +220,9 @@ name-group=
 include-naming-hint=no
 
 # Regular expression matching correct function names
-function-rgx=[a-z_][a-z0-9_]{2,30}$
+# original:
+#function-rgx=[a-z_][a-z0-9_]{2,30}$
+function-rgx=[a-zA-Z_][a-zA-Z0-9_]{2,40}$
 
 # Naming hint for function names
 function-name-hint=[a-z_][a-z0-9_]{2,30}$
@@ -228,7 +234,9 @@ variable-rgx=[a-z_][a-z0-9_]{2,30}$
 variable-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression matching correct constant names
-const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+# original:
+#const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+const-rgx=(([a-zA-Z_][a-zA-Z0-9_]*)|(__.*__))$
 
 # Naming hint for constant names
 const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
@@ -246,7 +254,9 @@ argument-rgx=[a-z_][a-z0-9_]{2,30}$
 argument-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression matching correct class attribute names
-class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+# original:
+#class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,40}|(__.*__))$
 
 # Naming hint for class attribute names
 class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
@@ -258,7 +268,9 @@ inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
 
 # Regular expression matching correct class names
-class-rgx=[A-Z_][a-zA-Z0-9]+$
+# original:
+#class-rgx=[A-Z_][a-zA-Z0-9]+$
+class-rgx=[a-zA-Z_][a-zA-Z0-9]+$
 
 # Naming hint for class names
 class-name-hint=[A-Z_][a-zA-Z0-9]+$
@@ -270,7 +282,9 @@ module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 
 # Regular expression matching correct method names
-method-rgx=[a-z_][a-z0-9_]{2,30}$
+# original:
+#method-rgx=[a-z_][a-z0-9_]{2,30}$
+method-rgx=[a-zA-Z_][a-zA-Z0-9_]{2,40}$
 
 # Naming hint for method names
 method-name-hint=[a-z_][a-z0-9_]{2,30}$

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,430 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Allow optimization of some AST trees. This will activate a peephole AST
+# optimizer, which will apply various small optimizations. For instance, it can
+# be used to obtain the result of joining multiple strings with the addition
+# operator. Joining a lot of strings can lead to a maximum recursion error in
+# Pylint and this flag can prevent that. It has one side effect, the resulting
+# AST will be different than the one from reality.
+optimize-ast=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=
+    # disabled by default,
+    import-star-module-level,
+    old-octal-literal,
+    oct-method,
+    print-statement,
+    unpacking-in-except,
+    parameter-unpacking,
+    backtick,
+    old-raise-syntax,
+    old-ne-operator,
+    long-suffix,
+    dict-view-method,
+    dict-iter-method,
+    metaclass-assignment,
+    next-method-called,
+    raising-string,
+    indexing-exception,
+    raw_input-builtin,
+    long-builtin,
+    file-builtin,
+    execfile-builtin,
+    coerce-builtin,
+    cmp-builtin,
+    buffer-builtin,
+    basestring-builtin,
+    apply-builtin,
+    filter-builtin-not-iterating,
+    using-cmp-argument,
+    useless-suppression,
+    range-builtin-not-iterating,
+    suppressed-message,
+    no-absolute-import,
+    old-division,
+    cmp-method,
+    reload-builtin,
+    zip-builtin-not-iterating,
+    intern-builtin,
+    unichr-builtin,
+    reduce-builtin,
+    standarderror-builtin,
+    unicode-builtin,
+    xrange-builtin,
+    coerce-method,
+    delslice-method,
+    getslice-method,
+    setslice-method,
+    input-builtin,
+    round-builtin,
+    hex-method,
+    nonzero-method,
+    map-builtin-not-iterating,
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[BASIC]
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,input
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[ELIF]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set). This supports can work
+# with qualified names.
+ignored-classes=
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception


### PR DESCRIPTION
Configure pylint for your project.
Pylint is overly picky by default, but I've modified its defaults to match your style.
If you prefer, I can minimize the configuration to just the bits that differ from default.
The remaining lint I believe are valid. You can see them here:

```
$ git ls-files  | egrep -v '^yapftests/' | grep '\.py$' | xargs pylint
************* Module setup
R: 34, 2: Method could be a function (no-self-use)
W: 22, 0: Unused import yapftests (unused-import)
C: 19, 0: standard import "import sys" comes before "from setuptools import setup, Command" (wrong-import-order)
************* Module yapf
R:170, 0: Too many arguments (7/5) (too-many-arguments)
W:237,16: Used builtin function 'map'. Using a list comprehension can be clearer. (bad-builtin)
************* Module yapf.yapflib.blank_line_calculator
R:161, 2: Method could be a function (no-self-use)
************* Module yapf.yapflib.comment_splicer
R: 46, 2: Too many local variables (16/15) (too-many-locals)
R: 48, 4: Too many nested blocks (7/5) (too-many-nested-blocks)
R: 46, 2: Too many branches (14/12) (too-many-branches)
E:201,10: Instance of 'Symbols' has no 'simple_stmt' member (no-member)
************* Module yapf.yapflib.format_decision_state
R: 41, 0: Too many instance attributes (11/7) (too-many-instance-attributes)
R:123, 2: Too many return statements (18/6) (too-many-return-statements)
R:123, 2: Too many branches (32/12) (too-many-branches)
R:360, 2: Too many return statements (8/6) (too-many-return-statements)
R:507, 0: Too few public methods (0/2) (too-few-public-methods)
************* Module yapf.yapflib.format_token
R: 33, 0: Too few public methods (0/2) (too-few-public-methods)
R: 55, 0: Too many instance attributes (10/7) (too-many-instance-attributes)
R: 55, 0: Too many public methods (23/20) (too-many-public-methods)
W: 22, 0: Unused pytree imported from lib2to3 (unused-import)
************* Module yapf.yapflib.py3compat
W: 81, 0: Redefining built-in 'unicode' (redefined-builtin)
W: 31, 2: Redefining built-in 'range' (redefined-builtin)
W: 33, 2: Redefining built-in 'raw_input' (redefined-builtin)
C: 25, 2: Import "import codecs" should be placed at the top of the module (wrong-import-position)
C: 28, 2: Import "import functools" should be placed at the top of the module (wrong-import-position)
E: 29,14: Module 'functools' has no 'lru_cache' member (no-member)
E: 35, 2: Unable to import 'configparser' (import-error)
C: 35, 2: Import "import configparser" should be placed at the top of the module (wrong-import-position)
C: 41, 2: Import "import __builtin__" should be placed at the top of the module (wrong-import-position)
C: 42, 2: Import "import cStringIO" should be placed at the top of the module (wrong-import-position)
W: 48,29: Unused argument 'typed' (unused-argument)
W: 48,16: Unused argument 'maxsize' (unused-argument)
C: 57, 2: Import "from itertools import ifilter" should be placed at the top of the module (wrong-import-position)
C: 60, 2: Import "import ConfigParser as configparser" should be placed at the top of the module (wrong-import-position)
E: 76, 4: Instance of 'file' has no 'buffer' member (no-member)
R: 55, 2: Redefinition of range type from function to type (redefined-variable-type)
W: 57, 2: Unused ifilter imported from itertools (unused-import)
************* Module yapf.yapflib.pytree_unwrapper
R: 60, 0: Too many public methods (22/20) (too-many-public-methods)
************* Module yapf.yapflib.pytree_utils
R: 44, 0: Too few public methods (0/2) (too-few-public-methods)
E:131,23: Instance of 'Symbols' has no 'file_input' member (no-member)
************* Module yapf.yapflib.reformatter
R:243, 0: Too few public methods (0/2) (too-few-public-methods)
W:301, 2: Unused variable 'prev_penalty' (unused-variable)
R:454, 2: Too many nested blocks (6/5) (too-many-nested-blocks)
R:410, 0: Too many return statements (9/6) (too-many-return-statements)
R:410, 0: Too many branches (22/12) (too-many-branches)
************* Module yapf.yapflib.split_penalty
R:158, 2: Too many branches (14/12) (too-many-branches)
R:294, 2: Method could be a function (no-self-use)
R:298, 2: Method could be a function (no-self-use)
R:312, 2: Method could be a function (no-self-use)
************* Module yapf.yapflib.style
W: 41, 2: Using the global statement (global-statement)
************* Module yapf.yapflib.subtype_assigner
R: 61, 2: Too many branches (13/12) (too-many-branches)
W:280,47: Unused argument 'force' (unused-argument)
R:280, 2: Method could be a function (no-self-use)
R: 55, 0: Too many public methods (24/20) (too-many-public-methods)
E:340,27: Instance of 'Symbols' has no 'atom' member (no-member)
************* Module yapf.yapflib.unwrapped_line
R:271, 6: Too many boolean expressions in if statement (6/5) (too-many-boolean-expressions)
R:190, 0: Too many return statements (36/6) (too-many-return-statements)
R:190, 0: Too many branches (35/12) (too-many-branches)
R:334, 0: Too many return statements (12/6) (too-many-return-statements)
R:410, 0: Too many return statements (23/6) (too-many-return-statements)
R:410, 0: Too many branches (26/12) (too-many-branches)
W: 22, 0: Unused pytree imported from lib2to3 (unused-import)
************* Module yapf.yapflib.yapf_api
R: 54, 0: Too many arguments (7/5) (too-many-arguments)
R: 99, 0: Too many arguments (6/5) (too-many-arguments)
R:202, 0: Too many branches (13/12) (too-many-branches)


Report
======
2280 statements analysed.

Statistics by type
------------------

+---------+-------+-----------+-----------+------------+---------+
|type     |number |old number |difference |%documented |%badname |
+=========+=======+===========+===========+============+=========+
|module   |23     |23         |=          |86.96       |0.00     |
+---------+-------+-----------+-----------+------------+---------+
|class    |18     |18         |=          |88.89       |0.00     |
+---------+-------+-----------+-----------+------------+---------+
|method   |151    |151        |=          |45.03       |0.00     |
+---------+-------+-----------+-----------+------------+---------+
|function |115    |114        |+1.00      |87.83       |0.00     |
+---------+-------+-----------+-----------+------------+---------+



External dependencies
---------------------
::

    setuptools (setup)
    yapf (yapf.__main__,setup)
      \-yapflib
        \-blank_line_calculator (yapf.yapflib.yapf_api)
        \-comment_splicer (yapf.yapflib.yapf_api)
        \-continuation_splicer (yapf.yapflib.yapf_api)
        \-errors (yapf,yapf.yapflib.style,yapf.yapflib.file_resources)
        \-file_resources (yapf,yapf.yapflib.yapf_api)
        \-format_decision_state (yapf.yapflib.reformatter)
        \-format_token (yapf.yapflib.split_penalty,yapf.yapflib.unwrapped_line,yapf.yapflib.reformatter,yapf.yapflib.format_decision_state,yapf.yapflib.subtype_assigner,yapf.yapflib.continuation_splicer)
        \-line_joiner (yapf.yapflib.reformatter)
        \-py3compat (yapf.yapflib.file_resources,yapf.yapflib.split_penalty,yapf,yapf.yapflib.format_token,yapf.yapflib.yapf_api,yapf.yapflib.unwrapped_line,yapf.yapflib.style,yapf.yapflib.blank_line_calculator)
        \-pytree_unwrapper (yapf.yapflib.yapf_api)
        \-pytree_utils (yapf.yapflib.split_penalty,yapf.yapflib.format_token,yapf.yapflib.yapf_api,yapf.yapflib.unwrapped_line,yapf.yapflib.reformatter,yapf.yapflib.format_decision_state,yapf.yapflib.comment_splicer,yapf.yapflib.subtype_assigner,yapf.yapflib.pytree_visitor,yapf.yapflib.blank_line_calculator,yapf.yapflib.pytree_unwrapper)
        \-pytree_visitor (yapf.yapflib.blank_line_calculator,yapf.yapflib.pytree_unwrapper,yapf.yapflib.split_penalty,yapf.yapflib.subtype_assigner)
        \-reformatter (yapf.yapflib.yapf_api)
        \-split_penalty (yapf.yapflib.yapf_api,yapf.yapflib.pytree_unwrapper,yapf.yapflib.unwrapped_line,yapf.yapflib.format_decision_state)
        \-style (yapf.yapflib.file_resources,yapf.yapflib.split_penalty,yapf,yapf.yapflib.format_token,yapf.yapflib.yapf_api,yapf.yapflib.unwrapped_line,yapf.yapflib.reformatter,yapf.yapflib.format_decision_state,yapf.yapflib.line_joiner,yapf.yapflib.subtype_assigner)
        \-subtype_assigner (yapf.yapflib.yapf_api)
        \-unwrapped_line (yapf.yapflib.pytree_unwrapper,yapf.yapflib.format_decision_state)
        \-verifier (yapf.yapflib.reformatter)
    yapftests (setup)



Raw metrics
-----------

+----------+-------+------+---------+-----------+
|type      |number |%     |previous |difference |
+==========+=======+======+=========+===========+
|code      |2897   |52.53 |2890     |+7.00      |
+----------+-------+------+---------+-----------+
|docstring |1165   |21.12 |1165     |=          |
+----------+-------+------+---------+-----------+
|comment   |751    |13.62 |746      |+5.00      |
+----------+-------+------+---------+-----------+
|empty     |702    |12.73 |700      |+2.00      |
+----------+-------+------+---------+-----------+



Duplication
-----------

+-------------------------+------+---------+-----------+
|                         |now   |previous |difference |
+=========================+======+=========+===========+
|nb duplicated lines      |0     |0        |=          |
+-------------------------+------+---------+-----------+
|percent duplicated lines |0.000 |0.000    |=          |
+-------------------------+------+---------+-----------+



Messages by category
--------------------

+-----------+-------+---------+-----------+
|type       |number |previous |difference |
+===========+=======+=========+===========+
|convention |8      |8        |=          |
+-----------+-------+---------+-----------+
|refactor   |37     |37       |=          |
+-----------+-------+---------+-----------+
|warning    |13     |13       |=          |
+-----------+-------+---------+-----------+
|error      |6      |6        |=          |
+-----------+-------+---------+-----------+



% errors / warnings by module
-----------------------------

+-----------------------------------+------+--------+---------+-----------+
|module                             |error |warning |refactor |convention |
+===================================+======+========+=========+===========+
|yapf.yapflib.py3compat             |50.00 |46.15   |2.70     |87.50      |
+-----------------------------------+------+--------+---------+-----------+
|yapf.yapflib.subtype_assigner      |16.67 |7.69    |8.11     |0.00       |
+-----------------------------------+------+--------+---------+-----------+
|yapf.yapflib.comment_splicer       |16.67 |0.00    |8.11     |0.00       |
+-----------------------------------+------+--------+---------+-----------+
|yapf.yapflib.pytree_utils          |16.67 |0.00    |2.70     |0.00       |
+-----------------------------------+------+--------+---------+-----------+
|yapf.yapflib.unwrapped_line        |0.00  |7.69    |16.22    |0.00       |
+-----------------------------------+------+--------+---------+-----------+
|yapf.yapflib.reformatter           |0.00  |7.69    |10.81    |0.00       |
+-----------------------------------+------+--------+---------+-----------+
|yapf.yapflib.format_token          |0.00  |7.69    |8.11     |0.00       |
+-----------------------------------+------+--------+---------+-----------+
|setup                              |0.00  |7.69    |2.70     |12.50      |
+-----------------------------------+------+--------+---------+-----------+
|yapf.__init__                      |0.00  |7.69    |2.70     |0.00       |
+-----------------------------------+------+--------+---------+-----------+
|yapf.yapflib.style                 |0.00  |7.69    |0.00     |0.00       |
+-----------------------------------+------+--------+---------+-----------+
|yapf.yapflib.format_decision_state |0.00  |0.00    |13.51    |0.00       |
+-----------------------------------+------+--------+---------+-----------+
|yapf.yapflib.split_penalty         |0.00  |0.00    |10.81    |0.00       |
+-----------------------------------+------+--------+---------+-----------+
|yapf.yapflib.yapf_api              |0.00  |0.00    |8.11     |0.00       |
+-----------------------------------+------+--------+---------+-----------+
|yapf.yapflib.pytree_unwrapper      |0.00  |0.00    |2.70     |0.00       |
+-----------------------------------+------+--------+---------+-----------+
|yapf.yapflib.blank_line_calculator |0.00  |0.00    |2.70     |0.00       |
+-----------------------------------+------+--------+---------+-----------+



Messages
--------

+-----------------------------+------------+
|message id                   |occurrences |
+=============================+============+
|too-many-branches            |8           |
+-----------------------------+------------+
|wrong-import-position        |7           |
+-----------------------------+------------+
|too-many-return-statements   |6           |
+-----------------------------+------------+
|no-self-use                  |6           |
+-----------------------------+------------+
|no-member                    |5           |
+-----------------------------+------------+
|unused-import                |4           |
+-----------------------------+------------+
|too-few-public-methods       |4           |
+-----------------------------+------------+
|unused-argument              |3           |
+-----------------------------+------------+
|too-many-public-methods      |3           |
+-----------------------------+------------+
|too-many-arguments           |3           |
+-----------------------------+------------+
|redefined-builtin            |3           |
+-----------------------------+------------+
|too-many-nested-blocks       |2           |
+-----------------------------+------------+
|too-many-instance-attributes |2           |
+-----------------------------+------------+
|wrong-import-order           |1           |
+-----------------------------+------------+
|unused-variable              |1           |
+-----------------------------+------------+
|too-many-locals              |1           |
+-----------------------------+------------+
|too-many-boolean-expressions |1           |
+-----------------------------+------------+
|redefined-variable-type      |1           |
+-----------------------------+------------+
|import-error                 |1           |
+-----------------------------+------------+
|global-statement             |1           |
+-----------------------------+------------+
|bad-builtin                  |1           |
+-----------------------------+------------+



Global evaluation
-----------------
Your code has been rated at 9.61/10 (previous run: 9.61/10, +0.00)
```