### PR TITLE
configure flake8 to match your style

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,8 @@
+[flake8]
+ignore =
+    # indentation is not a multiple of four,
+    E111,E114,
+    # visually indented line with same indent as next logical line,
+    E129
+
+max-line-length=80


### PR DESCRIPTION
Apparently you can't tell flake8/pep8 to use two-space indents, so I had to disable three checks.
