### PR TITLE
fixed #228: make exit code customizable to indicate whether files were changed

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,11 @@
 ### Fixed
 - Enforce splitting each element in a dictionary if comma terminated.
 
+### Changed
+- Issue #228: Return exit code 0 on success, regardless of whether files were
+  changed.  (Previously, 0 meant success with no files
+  modified, and 2 meant success with at least one file modified.)
+
 ## [0.11.0] 2016-07-17
 ### Added
 - The COALESCE_BRACKETS knob prevents splitting consecutive brackets when

--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -88,12 +88,6 @@ def main(argv):
       help='range of lines to reformat, one-based')
 
   parser.add_argument(
-      '-c',
-      '--changed-files-exit-code',
-      default=0,
-      type=int,
-      help='exit code to indicate that files were changed')
-  parser.add_argument(
       '-e',
       '--exclude',
       metavar='PATTERN',
@@ -167,7 +161,7 @@ def main(argv):
         lines=lines,
         verify=args.verify)
     sys.stdout.write(reformatted_source)
-    return args.changed_files_exit_code if changed else 0
+    return 0
 
   files = file_resources.GetCommandLineFiles(args.files, args.recursive,
                                              args.exclude)
@@ -181,7 +175,7 @@ def main(argv):
       in_place=args.in_place,
       print_diff=args.diff,
       verify=args.verify)
-  return args.changed_files_exit_code if changed else 0
+  return 0
 
 
 def FormatFiles(filenames,

--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -88,6 +88,12 @@ def main(argv):
       help='range of lines to reformat, one-based')
 
   parser.add_argument(
+      '-c',
+      '--changed-files-exit-code',
+      default=0,
+      type=int,
+      help='exit code to indicate that files were changed')
+  parser.add_argument(
       '-e',
       '--exclude',
       metavar='PATTERN',
@@ -161,7 +167,7 @@ def main(argv):
         lines=lines,
         verify=args.verify)
     sys.stdout.write(reformatted_source)
-    return 2 if changed else 0
+    return args.changed_files_exit_code if changed else 0
 
   files = file_resources.GetCommandLineFiles(args.files, args.recursive,
                                              args.exclude)
@@ -175,7 +181,7 @@ def main(argv):
       in_place=args.in_place,
       print_diff=args.diff,
       verify=args.verify)
-  return 2 if changed else 0
+  return args.changed_files_exit_code if changed else 0
 
 
 def FormatFiles(filenames,

--- a/yapftests/main_test.py
+++ b/yapftests/main_test.py
@@ -91,7 +91,7 @@ class MainTest(unittest.TestCase):
     with patched_input(code):
       with captured_output() as (out, err):
         ret = yapf.main(['-', '--style=chromium'])
-        self.assertEqual(ret, 2)
+        self.assertEqual(ret, 0)
         self.assertEqual(out.getvalue(), chromium_code)
 
   def testEchoBadInput(self):
@@ -116,3 +116,25 @@ class MainTest(unittest.TestCase):
       self.assertEqual(ret, 0)
       version = 'yapf {}\n'.format(yapf.__version__)
       self.assertEqual(version, out.getvalue())
+
+  def testUnchangedFileExitCode(self):
+    code = "a = 1"
+    with patched_input(code):
+      with captured_output() as (out, err):
+        ret = yapf.main([])
+        self.assertEqual(ret, 0)
+        
+  def testChangedFileExitCode(self):
+    code = "a=1"
+    with patched_input(code):
+      with captured_output() as (out, err):
+        ret = yapf.main([])
+        self.assertEqual(ret, 0)
+
+  def testCustomChangedFileExitCode(self):
+    code = "a=1"
+    with patched_input(code):
+      with captured_output() as (out, err):
+        ret = yapf.main(['-', '-c', '2'])
+        self.assertEqual(ret, 2)
+        

--- a/yapftests/main_test.py
+++ b/yapftests/main_test.py
@@ -117,24 +117,3 @@ class MainTest(unittest.TestCase):
       version = 'yapf {}\n'.format(yapf.__version__)
       self.assertEqual(version, out.getvalue())
 
-  def testUnchangedFileExitCode(self):
-    code = "a = 1"
-    with patched_input(code):
-      with captured_output() as (out, err):
-        ret = yapf.main([])
-        self.assertEqual(ret, 0)
-        
-  def testChangedFileExitCode(self):
-    code = "a=1"
-    with patched_input(code):
-      with captured_output() as (out, err):
-        ret = yapf.main([])
-        self.assertEqual(ret, 0)
-
-  def testCustomChangedFileExitCode(self):
-    code = "a=1"
-    with patched_input(code):
-      with captured_output() as (out, err):
-        ret = yapf.main(['-', '-c', '2'])
-        self.assertEqual(ret, 2)
-        


### PR DESCRIPTION
As with others on #228, I was surprised to learn that yapf returns a non-success error code even when it completes successfully. This breaks long-standing convention (that, yes, is broken by other tools also). 

The attached patch makes the return code in the case of changed files customizable. By default, 0 is returned when files are formatted according to the effective style, regardless of whether changes occurred or not. Callers may request that another exit code be used to indicate successful execution AND that files were modified. For example, `yapf -c 2` recovers the previous behavior to exit with code 2.
