### PR TITLE
Fix typos in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Daniel Jasper. In essence, the algorithm takes the code and reformats it to the
 best formatting that conforms to the style guide, even if the original code
 didn't violate the style guide. The idea is also similar to the 'gofmt' tool for
 the Go programming language: end all holy wars about formatting - if the whole
-code base of a project is simply piped through YAPF whenever modifications are
+codebase of a project is simply piped through YAPF whenever modifications are
 made, the style remains consistent throughout the project and there's no point
 arguing about style in every code review.
 
@@ -349,7 +349,7 @@ Knobs
 
 ``I18N_FUNCTION_CALL``
     The internationalization function call names. The presence of this function
-    stops reformattting on that line, because the string it has cannot be moved
+    stops reformatting on that line, because the string it has cannot be moved
     away from the i18n comment.
 
 ``INDENT_DICTIONARY_VALUE``


### PR DESCRIPTION
"code base" with a space is not really a typo per se,
but the spelling is now uniform across the README.