### PR TITLE
Added __hash__ and __eq__ to _ParenState

### DIFF
--- a/yapf/yapflib/format_decision_state.py
+++ b/yapf/yapflib/format_decision_state.py
@@ -633,3 +633,10 @@ class _ParenState(object):
   def __repr__(self):
     return '[indent::%d, last_space::%d, closing_scope_indent::%d]' % (
         self.indent, self.last_space, self.closing_scope_indent)
+
+  def __eq__(self, other):
+    return hash(self) == hash(other)
+
+  def __hash__(self, *args, **kwargs):
+    return hash((self.indent, self.last_space, self.closing_scope_indent,
+                 self.split_before_closing_bracket, self.num_line_splits))

--- a/yapf/yapflib/format_decision_state.py
+++ b/yapf/yapflib/format_decision_state.py
@@ -637,6 +637,9 @@ class _ParenState(object):
   def __eq__(self, other):
     return hash(self) == hash(other)
 
+  def __ne__(self, other):
+    return not self == other
+
   def __hash__(self, *args, **kwargs):
     return hash((self.indent, self.last_space, self.closing_scope_indent,
                  self.split_before_closing_bracket, self.num_line_splits))


### PR DESCRIPTION
This should fix some state duplication in sets, and speed up overall process.

---

Did some profiling and found an unusual number of states in sets created by `_AnalyzeSolutionSpace`, turns out that there was something funky with state stacks.

This change reduced `python setup.py test` time from `4.14s` to `2.69s` in my machine, and formatting a particularly slow file in another project went from `5.65s` to `1.84s`.