### PR TITLE
Fix yapf for windows line endings.

### DIFF
--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -220,8 +220,8 @@ def FormatFiles(filenames,
           verify=verify,
           logger=logging.warning)
       if not in_place and reformatted_code:
-        file_resources.WriteReformattedCode(filename, reformatted_code,
-                                            in_place, encoding)
+        file_resources.WriteReformattedCode(
+            filename, reformatted_code, in_place=in_place, encoding=encoding)
     except SyntaxError as e:
       e.filename = filename
       raise

--- a/yapf/yapflib/file_resources.py
+++ b/yapf/yapflib/file_resources.py
@@ -78,6 +78,7 @@ def GetCommandLineFiles(command_line_file_list, recursive, exclude):
 
 def WriteReformattedCode(filename,
                          reformatted_code,
+                         newline=os.linesep,
                          in_place=False,
                          encoding=''):
   """Emit the reformatted code.
@@ -88,12 +89,13 @@ def WriteReformattedCode(filename,
   Arguments:
     filename: (unicode) The name of the unformatted file.
     reformatted_code: (unicode) The reformatted code.
+    newline: (unicode) The original line ending of the source file.
     in_place: (bool) If True, then write the reformatted code to the file.
     encoding: (unicode) The encoding of the file.
   """
   if in_place:
     with py3compat.open_with_encoding(
-        filename, mode='w', encoding=encoding) as fd:
+        filename, mode='w', encoding=encoding, newline=newline) as fd:
       fd.write(reformatted_code)
   else:
     py3compat.EncodeAndWriteToStdout(reformatted_code)

--- a/yapf/yapflib/py3compat.py
+++ b/yapf/yapflib/py3compat.py
@@ -24,7 +24,7 @@ if PY3:
 
   import codecs
 
-  def open_with_encoding(filename, mode, encoding, newline=''):  # pylint: disable=unused-argument
+  def open_with_encoding(filename, mode, encoding, newline=''):
     return codecs.open(filename, mode=mode, encoding=encoding)
 
   import functools

--- a/yapf/yapflib/yapf_api.py
+++ b/yapf/yapflib/yapf_api.py
@@ -93,7 +93,7 @@ def FormatFile(filename,
     reformatted_source = newline.join(line for line in lines) + newline
   if in_place:
     if original_source and original_source != reformatted_source:
-      file_resources.WriteReformattedCode(filename, reformatted_source,
+      file_resources.WriteReformattedCode(filename, reformatted_source, newline,
                                           in_place, encoding)
     return None, encoding, changed
 


### PR DESCRIPTION
This reverts commit fa35006489c0b263e644926b2ad323970c487a67 and makes
sure to open file with correct newline for writing.

See https://github.com/google/yapf/issues/337