### PR TITLE
Add handling for unpacking with dict expressions (currently 3.6 only)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - 2.7
   - 3.4
   - 3.5
+  - 3.6
   - nightly
 
 matrix:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35
+envlist=py27,py34,py35,py36
 
 [testenv]
 commands=

--- a/yapf/yapflib/py3compat.py
+++ b/yapf/yapflib/py3compat.py
@@ -17,6 +17,7 @@ import io
 import sys
 
 PY3 = sys.version_info[0] == 3
+PY36 = sys.version_info[0] == 3 and sys.version_info[1] == 6
 
 if PY3:
   StringIO = io.StringIO

--- a/yapf/yapflib/py3compat.py
+++ b/yapf/yapflib/py3compat.py
@@ -17,7 +17,7 @@ import io
 import sys
 
 PY3 = sys.version_info[0] == 3
-PY36 = sys.version_info[0] == 3 and sys.version_info[1] == 6
+PY36 = sys.version_info[0] == 3 and sys.version_info[1] >= 6
 
 if PY3:
   StringIO = io.StringIO

--- a/yapf/yapflib/subtype_assigner.py
+++ b/yapf/yapflib/subtype_assigner.py
@@ -82,7 +82,7 @@ class _SubtypeAssigner(pytree_visitor.PyTreeVisitor):
       last_was_colon = False
       for child in node.children:
         if dict_maker:
-          if pytree_utils.NodeName(child) == "DOUBLESTAR":
+          if pytree_utils.NodeName(child) == 'DOUBLESTAR':
             _AppendFirstLeafTokenSubtype(child, format_token.Subtype.KWARGS_STAR_STAR)
           if last_was_colon:
             if style.Get('INDENT_DICTIONARY_VALUE'):

--- a/yapf/yapflib/subtype_assigner.py
+++ b/yapf/yapflib/subtype_assigner.py
@@ -75,13 +75,15 @@ class _SubtypeAssigner(pytree_visitor.PyTreeVisitor):
         comp_for = True
         _AppendFirstLeafTokenSubtype(child,
                                      format_token.Subtype.DICT_SET_GENERATOR)
-      elif pytree_utils.NodeName(child) == 'COLON':
+      elif pytree_utils.NodeName(child) in ('COLON', 'DOUBLESTAR'):
         dict_maker = True
 
     if not comp_for and dict_maker:
       last_was_colon = False
       for child in node.children:
         if dict_maker:
+          if pytree_utils.NodeName(child) == "DOUBLESTAR":
+            _AppendFirstLeafTokenSubtype(child, format_token.Subtype.KWARGS_STAR_STAR)
           if last_was_colon:
             if style.Get('INDENT_DICTIONARY_VALUE'):
               _InsertPseudoParentheses(child)

--- a/yapftests/reformatter_python3_test.py
+++ b/yapftests/reformatter_python3_test.py
@@ -59,6 +59,23 @@ class TestsForPython3Code(yapf_test_helper.YAPFTest):
     uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
     self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
 
+  @unittest.skipUnless(py3compat.PY36, 'Requires Python 3.6')
+  def testPEP448ParameterExpansion(self):
+    unformatted_code = textwrap.dedent("""\
+    { ** x }
+    {   **{}   }
+    { **{   **x },  **x }
+    {'a': 1,   **kw , 'b':3,  **kw2   }
+    """)
+    expected_formatted_code = textwrap.dedent("""\
+    {**x}
+    {**{}}
+    {**{**x}, **x}
+    {'a': 1, **kw, 'b': 3, **kw2}
+    """)
+    uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
+    self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
+
   def testAnnotations(self):
     unformatted_code = textwrap.dedent("""\
         def foo(a: list, b: "bar") -> dict:


### PR DESCRIPTION
Only works on Python 3.6, since lib2to3 in Python 3.5 doesn't
recognize the unpacking token.

Prior to this patch,
```{**x}```
would raise an error like this in Python 3.5: 
```lib2to3.pgen2.parse.ParseError: bad input: type=36, value='**', context=('   ', (1, 11))```.

This is a known issue.

In Python 3.6, this is apparently fixed, so that we can indeed support PEP448 cases.

