### PR TITLE
Fix unittest to work on Windows (python 2 and 3)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,9 @@
 ### Fixed
 - Split before all entries in a dict/set or list maker when comma-terminated,
   even if there's only one entry.
+- Will now try to set O_BINARY mode on stdout under Windows and Python 2.
+- Avoid unneeded newline transformation when writing formatted code to
+  output on (affects only Python 2)
 
 ## [0.15.2] 2017-01-29
 ### Fixed

--- a/yapf/yapflib/file_resources.py
+++ b/yapf/yapflib/file_resources.py
@@ -93,7 +93,7 @@ def WriteReformattedCode(filename,
   """
   if in_place:
     with py3compat.open_with_encoding(
-        filename, mode='w', encoding=encoding) as fd:
+        filename, mode='w', encoding=encoding, newline='') as fd:
       fd.write(reformatted_code)
   else:
     py3compat.EncodeAndWriteToStdout(reformatted_code)

--- a/yapftests/file_resources_test.py
+++ b/yapftests/file_resources_test.py
@@ -14,10 +14,8 @@
 # limitations under the License.
 """Tests for yapf.file_resources."""
 
-import contextlib
 import os
 import shutil
-import sys
 import tempfile
 import unittest
 
@@ -25,15 +23,7 @@ from yapf.yapflib import errors
 from yapf.yapflib import file_resources
 from yapf.yapflib import py3compat
 
-
-@contextlib.contextmanager
-def stdout_redirector(stream):  # pylint: disable=invalid-name
-  old_stdout = sys.stdout
-  sys.stdout = stream
-  try:
-    yield
-  finally:
-    sys.stdout = old_stdout
+from .utils import NamedTempFile, stdout_redirector
 
 
 class GetDefaultStyleForDirTest(unittest.TestCase):
@@ -77,7 +67,7 @@ class GetCommandLineFilesTest(unittest.TestCase):
     shutil.rmtree(self.test_tmpdir)
 
   def _make_test_dir(self, name):
-    fullpath = os.path.join(self.test_tmpdir, name)
+    fullpath = os.path.normpath(os.path.join(self.test_tmpdir, name))
     os.makedirs(fullpath)
     return fullpath
 
@@ -213,13 +203,13 @@ class WriteReformattedCodeTest(unittest.TestCase):
 
   def test_write_to_file(self):
     s = u'foobar\n'
-    with tempfile.NamedTemporaryFile(dir=self.test_tmpdir) as testfile:
+    with NamedTempFile(dir=self.test_tmpdir) as (f, fname):
       file_resources.WriteReformattedCode(
-          testfile.name, s, in_place=True, encoding='utf-8')
-      testfile.flush()
+          fname, s, in_place=True, encoding='utf-8')
+      f.flush()
 
-      with open(testfile.name) as f:
-        self.assertEqual(f.read(), s)
+      with open(fname) as f2:
+        self.assertEqual(f2.read(), s)
 
   def test_write_to_stdout(self):
     s = u'foobar'

--- a/yapftests/style_test.py
+++ b/yapftests/style_test.py
@@ -14,13 +14,14 @@
 # limitations under the License.
 """Tests for yapf.style."""
 
-import contextlib
 import shutil
 import tempfile
 import textwrap
 import unittest
 
 from yapf.yapflib import style
+
+from .utils import TempFileContents
 
 
 class UtilsTest(unittest.TestCase):
@@ -90,14 +91,6 @@ class PredefinedStylesByNameTest(unittest.TestCase):
       self.assertTrue(_LooksLikeFacebookStyle(cfg))
 
 
-@contextlib.contextmanager
-def _TempFileContents(dirname, contents):
-  with tempfile.NamedTemporaryFile(dir=dirname, mode='w') as f:
-    f.write(contents)
-    f.flush()
-    yield f
-
-
 class StyleFromFileTest(unittest.TestCase):
 
   @classmethod
@@ -110,80 +103,80 @@ class StyleFromFileTest(unittest.TestCase):
     shutil.rmtree(cls.test_tmpdir)
 
   def testDefaultBasedOnStyle(self):
-    cfg = textwrap.dedent('''\
+    cfg = textwrap.dedent(u'''\
         [style]
         continuation_indent_width = 20
         ''')
-    with _TempFileContents(self.test_tmpdir, cfg) as f:
-      cfg = style.CreateStyleFromConfig(f.name)
+    with TempFileContents(self.test_tmpdir, cfg) as filepath:
+      cfg = style.CreateStyleFromConfig(filepath)
       self.assertTrue(_LooksLikePEP8Style(cfg))
       self.assertEqual(cfg['CONTINUATION_INDENT_WIDTH'], 20)
 
   def testDefaultBasedOnPEP8Style(self):
-    cfg = textwrap.dedent('''\
+    cfg = textwrap.dedent(u'''\
         [style]
         based_on_style = pep8
         continuation_indent_width = 40
         ''')
-    with _TempFileContents(self.test_tmpdir, cfg) as f:
-      cfg = style.CreateStyleFromConfig(f.name)
+    with TempFileContents(self.test_tmpdir, cfg) as filepath:
+      cfg = style.CreateStyleFromConfig(filepath)
       self.assertTrue(_LooksLikePEP8Style(cfg))
       self.assertEqual(cfg['CONTINUATION_INDENT_WIDTH'], 40)
 
   def testDefaultBasedOnChromiumStyle(self):
-    cfg = textwrap.dedent('''\
+    cfg = textwrap.dedent(u'''\
         [style]
         based_on_style = chromium
         continuation_indent_width = 30
         ''')
-    with _TempFileContents(self.test_tmpdir, cfg) as f:
-      cfg = style.CreateStyleFromConfig(f.name)
+    with TempFileContents(self.test_tmpdir, cfg) as filepath:
+      cfg = style.CreateStyleFromConfig(filepath)
       self.assertTrue(_LooksLikeChromiumStyle(cfg))
       self.assertEqual(cfg['CONTINUATION_INDENT_WIDTH'], 30)
 
   def testDefaultBasedOnGoogleStyle(self):
-    cfg = textwrap.dedent('''\
+    cfg = textwrap.dedent(u'''\
         [style]
         based_on_style = google
         continuation_indent_width = 20
         ''')
-    with _TempFileContents(self.test_tmpdir, cfg) as f:
-      cfg = style.CreateStyleFromConfig(f.name)
+    with TempFileContents(self.test_tmpdir, cfg) as filepath:
+      cfg = style.CreateStyleFromConfig(filepath)
       self.assertTrue(_LooksLikeGoogleStyle(cfg))
       self.assertEqual(cfg['CONTINUATION_INDENT_WIDTH'], 20)
 
   def testDefaultBasedOnFacebookStyle(self):
-    cfg = textwrap.dedent('''\
+    cfg = textwrap.dedent(u'''\
         [style]
         based_on_style = facebook
         continuation_indent_width = 20
         ''')
-    with _TempFileContents(self.test_tmpdir, cfg) as f:
-      cfg = style.CreateStyleFromConfig(f.name)
+    with TempFileContents(self.test_tmpdir, cfg) as filepath:
+      cfg = style.CreateStyleFromConfig(filepath)
       self.assertTrue(_LooksLikeFacebookStyle(cfg))
       self.assertEqual(cfg['CONTINUATION_INDENT_WIDTH'], 20)
 
   def testBoolOptionValue(self):
-    cfg = textwrap.dedent('''\
+    cfg = textwrap.dedent(u'''\
         [style]
         based_on_style = chromium
         SPLIT_BEFORE_NAMED_ASSIGNS=False
         split_before_logical_operator = true
         ''')
-    with _TempFileContents(self.test_tmpdir, cfg) as f:
-      cfg = style.CreateStyleFromConfig(f.name)
+    with TempFileContents(self.test_tmpdir, cfg) as filepath:
+      cfg = style.CreateStyleFromConfig(filepath)
       self.assertTrue(_LooksLikeChromiumStyle(cfg))
       self.assertEqual(cfg['SPLIT_BEFORE_NAMED_ASSIGNS'], False)
       self.assertEqual(cfg['SPLIT_BEFORE_LOGICAL_OPERATOR'], True)
 
   def testStringListOptionValue(self):
-    cfg = textwrap.dedent('''\
+    cfg = textwrap.dedent(u'''\
         [style]
         based_on_style = chromium
         I18N_FUNCTION_CALL = N_, V_, T_
         ''')
-    with _TempFileContents(self.test_tmpdir, cfg) as f:
-      cfg = style.CreateStyleFromConfig(f.name)
+    with TempFileContents(self.test_tmpdir, cfg) as filepath:
+      cfg = style.CreateStyleFromConfig(filepath)
       self.assertTrue(_LooksLikeChromiumStyle(cfg))
       self.assertEqual(cfg['I18N_FUNCTION_CALL'], ['N_', 'V_', 'T_'])
 
@@ -193,25 +186,25 @@ class StyleFromFileTest(unittest.TestCase):
       style.CreateStyleFromConfig('/8822/xyznosuchfile')
 
   def testErrorNoStyleSection(self):
-    cfg = textwrap.dedent('''\
+    cfg = textwrap.dedent(u'''\
         [s]
         indent_width=2
         ''')
-    with _TempFileContents(self.test_tmpdir, cfg) as f:
+    with TempFileContents(self.test_tmpdir, cfg) as filepath:
       with self.assertRaisesRegexp(style.StyleConfigError,
                                    'Unable to find section'):
-        style.CreateStyleFromConfig(f.name)
+        style.CreateStyleFromConfig(filepath)
 
   def testErrorUnknownStyleOption(self):
-    cfg = textwrap.dedent('''\
+    cfg = textwrap.dedent(u'''\
         [style]
         indent_width=2
         hummus=2
         ''')
-    with _TempFileContents(self.test_tmpdir, cfg) as f:
+    with TempFileContents(self.test_tmpdir, cfg) as filepath:
       with self.assertRaisesRegexp(style.StyleConfigError,
                                    'Unknown style option'):
-        style.CreateStyleFromConfig(f.name)
+        style.CreateStyleFromConfig(filepath)
 
 
 class StyleFromCommandLine(unittest.TestCase):

--- a/yapftests/utils.py
+++ b/yapftests/utils.py
@@ -38,69 +38,39 @@ def stdout_redirector(stream):  # pylint: disable=invalid-name
 #
 # Note: returns a tuple of (io.file_obj, file_path), instead of a file_obj with a
 # .name attribute
-if sys.version_info[0] >= 3:
-  # Note: `buffering` is set to -1 despite documentation of NamedTemporaryFile
-  # says None. This is probably a problem with the python documenation.
-  @contextlib.contextmanager
-  def NamedTempFile(mode='w+b',
-                    buffering=-1,
-                    encoding=None,
-                    errors=None,
-                    newline=None,
-                    suffix=None,
-                    prefix=None,
-                    dir=None,
-                    text=False):
-    """Context manager creating a new temporary file in text mode.
-    returns (fileobj, filepath)
-    """
-    if sys.version_info < (3, 5):
-      if suffix is None:
-        suffix = ''
-      if prefix is None:
-        prefix = 'tmp'
-    (fd, fname) = tempfile.mkstemp(
-        suffix=suffix, prefix=prefix, dir=dir, text=text)
-    f = open(
-        fd,
-        mode=mode,
-        buffering=buffering,
-        encoding=encoding,
-        errors=errors,
-        newline=newline)
-    yield f, fname
-    f.close()
-    os.remove(fname)
-
-else:
-  # Parameters `suffix` and `prefix` can't be set to None, so use values
-  # according to Python 2.7 documentation.
-  @contextlib.contextmanager
-  def NamedTempFile(mode='w+b',
-                    buffering=-1,
-                    encoding=None,
-                    errors=None,
-                    newline=None,
-                    suffix=None,
-                    prefix=None,
-                    dir=None,
-                    text=False):
+#
+# Note: `buffering` is set to -1 despite documentation of NamedTemporaryFile
+# says None. This is probably a problem with the python documenation.
+@contextlib.contextmanager
+def NamedTempFile(mode='w+b',
+                  buffering=-1,
+                  encoding=None,
+                  errors=None,
+                  newline=None,
+                  suffix=None,
+                  prefix=None,
+                  dir=None,
+                  text=False):
+  """Context manager creating a new temporary file in text mode.
+  returns (fileobj, filepath)
+  """
+  if sys.version_info < (3, 5):  # covers also python 2
     if suffix is None:
       suffix = ''
     if prefix is None:
       prefix = 'tmp'
-    (fd, fname) = tempfile.mkstemp(
-        suffix=suffix, prefix=prefix, dir=dir, text=text)
-    f = io.open(
-        fd,
-        mode=mode,
-        buffering=buffering,
-        encoding=encoding,
-        errors=errors,
-        newline=newline)
-    yield f, fname
-    f.close()
-    os.remove(fname)
+  (fd, fname) = tempfile.mkstemp(
+      suffix=suffix, prefix=prefix, dir=dir, text=text)
+  f = io.open(
+      fd,
+      mode=mode,
+      buffering=buffering,
+      encoding=encoding,
+      errors=errors,
+      newline=newline)
+  yield f, fname
+  f.close()
+  os.remove(fname)
 
 
 @contextlib.contextmanager

--- a/yapftests/utils.py
+++ b/yapftests/utils.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for tests"""
+
+import sys
+import os
+import tempfile
+import contextlib
+import io
+
+
+@contextlib.contextmanager
+def stdout_redirector(stream):  # pylint: disable=invalid-name
+  old_stdout = sys.stdout
+  sys.stdout = stream
+  try:
+    yield
+  finally:
+    sys.stdout = old_stdout
+
+
+# NamedTemporaryFile is useless because on Windows the temporary file would be
+# created with O_TEMPORARY, which would not allow the file to be opened a
+# second time, even by the same process, unless the same flag is used.
+# Thus we provide a simplifed version ourselfs.
+#
+# Note: returns a tuple of (io.file_obj, file_path), instead of a file_obj with a
+# .name attribute
+if sys.version_info[0] >= 3:
+  # Note: `buffering` is set to -1 despite documentation of NamedTemporaryFile
+  # says None. This is probably a problem with the python documenation.
+  @contextlib.contextmanager
+  def NamedTempFile(mode='w+b',
+                    buffering=-1,
+                    encoding=None,
+                    errors=None,
+                    newline=None,
+                    suffix=None,
+                    prefix=None,
+                    dir=None,
+                    text=False):
+    """Context manager creating a new temporary file in text mode.
+    returns (fileobj, filepath)
+    """
+    (fd, fname) = tempfile.mkstemp(
+        suffix=suffix, prefix=prefix, dir=dir, text=text)
+    f = open(
+        fd,
+        mode=mode,
+        buffering=buffering,
+        encoding=encoding,
+        errors=errors,
+        newline=newline)
+    yield f, fname
+    f.close()
+    os.remove(fname)
+
+else:
+  # Parameters `suffix` and `prefix` can't be set to None, so use values
+  # according to Python 2.7 documentation.
+  @contextlib.contextmanager
+  def NamedTempFile(mode='w+b',
+                    buffering=-1,
+                    encoding=None,
+                    errors=None,
+                    newline=None,
+                    suffix=None,
+                    prefix=None,
+                    dir=None,
+                    text=False):
+    if suffix is None:
+      suffix = ''
+    if prefix is None:
+      prefix = 'tmp'
+    (fd, fname) = tempfile.mkstemp(
+        suffix=suffix, prefix=prefix, dir=dir, text=text)
+    f = io.open(
+        fd,
+        mode=mode,
+        buffering=buffering,
+        encoding=encoding,
+        errors=errors,
+        newline=newline)
+    yield f, fname
+    f.close()
+    os.remove(fname)
+
+
+@contextlib.contextmanager
+def TempFileContents(dirname,
+                     contents,
+                     encoding='utf-8',
+                     newline='',
+                     suffix=None):
+  # Note: NamedTempFile properly handles unicode encoding when using mode='w'
+  with NamedTempFile(
+      dir=dirname, mode='w', encoding=encoding, newline=newline,
+      suffix=suffix) as (f, fname):
+    f.write(contents)
+    f.flush()
+    yield fname

--- a/yapftests/utils.py
+++ b/yapftests/utils.py
@@ -54,6 +54,11 @@ if sys.version_info[0] >= 3:
     """Context manager creating a new temporary file in text mode.
     returns (fileobj, filepath)
     """
+    if sys.version_info < (3, 5):
+      if suffix is None:
+        suffix = ''
+      if prefix is None:
+        prefix = 'tmp'
     (fd, fname) = tempfile.mkstemp(
         suffix=suffix, prefix=prefix, dir=dir, text=text)
     f = open(


### PR DESCRIPTION
tmpefile.NamedTemporaryFile does not work as expected. It will create a file with O_TEMPORARY on Windows which can only be opened by the same process and using the same flag.

So I have provided a alternative in a new file yapftest/utils.py, named NamedTempFile. I have also moved some other test utilities into this file: "TempFileContents" and "stdout_redirectory", both are context managers, as is NamedTempFile.

Note also that I have created a new test, which dumps --style-help to a file and tries to format a simple example using the style file. This would catch the "bug" that you momentarily introduced in master when you added the new knobs EACH_DICT_ENTRY_ON_SEPARATE_LINE SPLIT_BEFORE_DICT_SET_GENERATOR.

I have also fixed 2 small bugs that would occur on Python 2 on windows during the test cases. Mostly related to how newline transformation works. The still exist another bug that is neither fixed nor tested for specifically that "input" is used to read stdin which discards newlines and thus we have no idea what newlines to output. A proper fix for that would involve a small bit of refactoring to remove small unnecessary code.