### PR TITLE
Fix USE_TABS=True is ignored for continued indentation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,7 @@
   right-hand side. Split the arguments instead.
 - We need to split a dictionary value if the first element is a comment anyway,
   so don't force the split here. It's forced elsewhere.
+- Ensure tabs are used for continued indentation when USE_TABS is True.
 
 ## [0.16.0] 2017-02-05
 ### Added

--- a/yapf/yapflib/format_token.py
+++ b/yapf/yapflib/format_token.py
@@ -120,8 +120,9 @@ class FormatToken(object):
       indent_level: (int) The indentation level.
     """
     indent_char = '\t' if style.Get('USE_TABS') else ' '
+    token_indent_char = indent_char if newlines_before > 0 else ' '
     indent_before = (
-        indent_char * indent_level * style.Get('INDENT_WIDTH') + ' ' * spaces)
+        indent_char * indent_level * style.Get('INDENT_WIDTH') + token_indent_char * spaces)
 
     if self.is_comment:
       comment_lines = [s.lstrip() for s in self.value.splitlines()]


### PR DESCRIPTION
This PR fixes the bug that caused spaces to be used for continued indentation when USE_TABS=True.

At the moment the output is not optimal since it ends up adding more tab than needed, since it just replaces the continued indentation spaced with tabs, but at leas the code is executable. I could not find a way to reliably reduce the number of tab to be added without outputting invalid code.

Closes https://github.com/google/yapf/issues/328