### PR TITLE
Fix a regression related to coalesced brackets when using DEDENT_CLOSING_BRACKETS

### DIFF
--- a/yapf/yapflib/format_decision_state.py
+++ b/yapf/yapflib/format_decision_state.py
@@ -503,7 +503,7 @@ class FormatDecisionState(object):
           0, self.stack[-1].indent - style.Get('CONTINUATION_INDENT_WIDTH'))
 
       split_before_closing_bracket = True
-      if style.Get('COALESCE_BRACKETS'):
+      if style.Get('COALESCE_BRACKETS') and not style.Get('DEDENT_CLOSING_BRACKETS'):
         split_before_closing_bracket = False
 
       self.stack[-1].split_before_closing_bracket = split_before_closing_bracket


### PR DESCRIPTION
This fixes https://github.com/google/yapf/issues/415 where the final bracket of a function call was not being dendented even with `DEDENT_CLOSING_BRACKETS` set.

I think this PR is probably currently the wrong approach but I wanted to start a discussion about what the correct behaviour here is. Given that the documentation for `COALESCE_BRACKETS` states that it is "Only relevant when `DEDENT_CLOSING_BRACKETS` is set." I think that in all cases the code produced by setting `COALESCE_BRACKETS` but not `DEDENT_CLOSING_BRACKETS` should be the same as setting neither option - otherwise the documentation should be changed.

I'm interested what others think though & am happy to make changes to this pull request (and add tests) as required.