### PR TITLE
Vim plugin error check

### DIFF
--- a/plugins/vim/autoload/yapf.vim
+++ b/plugins/vim/autoload/yapf.vim
@@ -40,6 +40,13 @@ function! yapf#YAPF() range
         \ split(system(l:cmd, join(getline(1, '$'), "\n") . "\n"), "\n")
   endif
 
+  if v:shell_error
+    echohl ErrorMsg
+    echomsg printf('"%s" returned error: %s', l:cmd, l:formatted_text[-1])
+    echohl None
+    return
+  endif
+
   " Update the buffer.
   execute '1,' . string(line('$')) . 'delete'
   call setline(1, l:formatted_text)

--- a/plugins/vim/autoload/yapf.vim
+++ b/plugins/vim/autoload/yapf.vim
@@ -33,11 +33,16 @@ function! yapf#YAPF() range
   let l:cmd = 'yapf --lines=' . l:line_ranges
 
   " Call YAPF with the current buffer
-  let l:formatted_text = system(l:cmd, join(getline(1, '$'), "\n") . "\n")
+  if exists('*systemlist')
+    let l:formatted_text = systemlist(l:cmd, join(getline(1, '$'), "\n") . "\n")
+  else
+    let l:formatted_text =
+        \ split(system(l:cmd, join(getline(1, '$'), "\n") . "\n"), "\n")
+  endif
 
   " Update the buffer.
   execute '1,' . string(line('$')) . 'delete'
-  call setline(1, split(l:formatted_text, "\n"))
+  call setline(1, l:formatted_text)
 
   " Reset cursor to first line of the formatted range.
   call cursor(a:firstline, 1)


### PR DESCRIPTION
Vim plugin: don't clobber edited code if `yapf` command returned error.
Check `yapf` command exit code. If there was an error, show error message with the last line of output and don't change text in a buffer.