### PR TITLE
Configurable spaces around binary operators

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -399,6 +399,19 @@ Knobs
 ``SPACES_AROUND_POWER_OPERATOR``
     Set to ``True`` to prefer using spaces around ``**``.
 
+``NO_SPACES_AROUND_SELECTED_BINARY_OPERATORS``
+    Do not include spaces around selected binary operators. For example:
+
+    .. code-block:: python
+
+        1 + 2 * 3 - 4 / 5
+
+    will be formatted as follows when configured with a value ``"*,/"``:
+
+    .. code-block:: python
+
+        1 + 2*3 - 4/5
+
 ``SPACES_AROUND_DEFAULT_OR_NAMED_ASSIGN``
     Set to ``True`` to prefer spaces around the assignment operator for default
     or keyword arguments.

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -136,6 +136,16 @@ _STYLE_HELP = dict(
       etc."""),
     SPACES_AROUND_POWER_OPERATOR=textwrap.dedent("""\
       Use spaces around the power operator."""),
+    NO_SPACES_AROUND_SELECTED_BINARY_OPERATORS=textwrap.dedent("""\
+      Do not include spaces around selected binary operators. For example:
+
+        1 + 2 * 3 - 4 / 5
+
+      will be formatted as follows when configured with a value "*,/":
+
+        1 + 2*3 - 4/5
+
+      """),
     SPACES_AROUND_DEFAULT_OR_NAMED_ASSIGN=textwrap.dedent("""\
       Use spaces around default or named assigns."""),
     SPACES_BEFORE_COMMENT=textwrap.dedent("""\
@@ -216,6 +226,7 @@ def CreatePEP8Style():
       JOIN_MULTIPLE_LINES=True,
       SPACE_BETWEEN_ENDING_COMMA_AND_CLOSING_BRACKET=True,
       SPACES_AROUND_POWER_OPERATOR=False,
+      NO_SPACES_AROUND_SELECTED_BINARY_OPERATORS=set(),
       SPACES_AROUND_DEFAULT_OR_NAMED_ASSIGN=False,
       SPACES_BEFORE_COMMENT=2,
       SPLIT_ARGUMENTS_WHEN_COMMA_TERMINATED=False,
@@ -300,6 +311,11 @@ def _StringListConverter(s):
   return [part.strip() for part in s.split(',')]
 
 
+def _StringSetConverter(s):
+  """Option value converter for a comma-separated set of strings."""
+  return set(part.strip() for part in s.split(','))
+
+
 def _BoolConverter(s):
   """Option value converter for a boolean."""
   return py3compat.CONFIGPARSER_BOOLEAN_STATES[s.lower()]
@@ -329,6 +345,7 @@ _STYLE_OPTION_VALUE_CONVERTER = dict(
     INDENT_WIDTH=int,
     JOIN_MULTIPLE_LINES=_BoolConverter,
     SPACE_BETWEEN_ENDING_COMMA_AND_CLOSING_BRACKET=_BoolConverter,
+    NO_SPACES_AROUND_SELECTED_BINARY_OPERATORS=_StringSetConverter,
     SPACES_AROUND_POWER_OPERATOR=_BoolConverter,
     SPACES_AROUND_DEFAULT_OR_NAMED_ASSIGN=_BoolConverter,
     SPACES_BEFORE_COMMENT=int,

--- a/yapf/yapflib/unwrapped_line.py
+++ b/yapf/yapflib/unwrapped_line.py
@@ -253,8 +253,9 @@ def _SpaceRequiredBetween(left, right):
     if lval == '**' or rval == '**':
       # Space around the "power" operator.
       return style.Get('SPACES_AROUND_POWER_OPERATOR')
-    # Enforce spaces around binary operators.
-    return True
+    # Enforce spaces around binary operators except the blacklisted ones.
+    blacklist = style.Get('NO_SPACES_AROUND_SELECTED_BINARY_OPERATORS')
+    return lval not in blacklist and rval not in blacklist
   if (_IsUnaryOperator(left) and lval != 'not' and
       (right.is_name or right.is_number or rval == '(')):
     # The previous token was a unary op. No space is desired between it and

--- a/yapftests/reformatter_style_config_test.py
+++ b/yapftests/reformatter_style_config_test.py
@@ -57,5 +57,25 @@ class TestsForStyleConfig(yapf_test_helper.YAPFTest):
     self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
 
 
+  def testOperatorStyle(self):
+    try:
+      sympy_style = style.CreatePEP8Style()
+      sympy_style['NO_SPACES_AROUND_SELECTED_BINARY_OPERATORS'] = \
+        style._StringSetConverter('*,/')
+      style.SetGlobalStyle(sympy_style)
+      unformatted_code = textwrap.dedent("""\
+          a = 1+2 * 3 - 4 / 5
+          """)
+      expected_formatted_code = textwrap.dedent("""\
+          a = 1 + 2*3 - 4/5
+          """)
+
+      uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
+      self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
+    finally:
+      style.SetGlobalStyle(style.CreatePEP8Style())
+      style.DEFAULT_STYLE = self.current_style
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Adds configuration options to allow current SymPy style for spaces around binary operators.