### PR TITLE
Make yapf put the correct number of blank lines at --lines boundaries.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,10 @@
 # All notable changes to this project will be documented in this file.
 # This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.16.4] Unreleased
+### Changed
+- Adjust blank lines on formatting boundaries when using the `--lines` option.
+
 ## [0.16.3] 2017-07-13
 ### Changed
 - Add filename information to a ParseError excetion.

--- a/yapftests/blank_line_calculator_test.py
+++ b/yapftests/blank_line_calculator_test.py
@@ -18,6 +18,7 @@ import unittest
 
 from yapf.yapflib import reformatter
 from yapf.yapflib import style
+from yapf.yapflib import yapf_api
 
 from yapftests import yapf_test_helper
 
@@ -275,6 +276,79 @@ class BasicBlankLineCalculatorTest(yapf_test_helper.YAPFTest):
         """)
     uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
     self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
+
+  def testLinesOnRangeBoundary(self):
+    unformatted_code = textwrap.dedent(u"""\
+        def A():
+          pass
+
+        def B():  # 4
+          pass  # 5
+
+        def C():
+          pass
+        def D():  # 9
+          pass  # 10
+        def E():
+          pass
+        """)
+    expected_formatted_code = textwrap.dedent(u"""\
+        def A():
+          pass
+
+
+        def B():  # 4
+          pass  # 5
+
+
+        def C():
+          pass
+
+
+        def D():  # 9
+          pass  # 10
+
+
+        def E():
+          pass
+        """)
+    code, changed = yapf_api.FormatCode(
+        unformatted_code, lines=[(4, 5), (9, 10)])
+    self.assertCodeEqual(expected_formatted_code, code)
+    self.assertTrue(changed)
+
+  def testLinesRangeBoundaryNotOutside(self):
+    unformatted_code = textwrap.dedent(u"""\
+        def A():
+          pass
+
+
+
+        def B():  # 6
+          pass  # 7
+
+
+
+        def C():
+          pass
+        """)
+    expected_formatted_code = textwrap.dedent(u"""\
+        def A():
+          pass
+
+
+
+        def B():  # 6
+          pass  # 7
+
+
+
+        def C():
+          pass
+        """)
+    code, changed = yapf_api.FormatCode(unformatted_code, lines=[(6, 7)])
+    self.assertCodeEqual(expected_formatted_code, code)
+    self.assertFalse(changed)
 
 
 if __name__ == '__main__':

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -365,7 +365,7 @@ class CommandLineTest(unittest.TestCase):
         stderr=subprocess.PIPE)
     reformatted_code, stderrdata = p.communicate(unformatted.encode('utf-8'))
     self.assertEqual(stderrdata, b'')
-    self.assertEqual(reformatted_code.decode('utf-8'), expected)
+    self.assertMultiLineEqual(reformatted_code.decode('utf-8'), expected)
 
   def testUnicodeEncodingPipedToFile(self):
     unformatted_code = textwrap.dedent(u"""\
@@ -775,6 +775,8 @@ class CommandLineTest(unittest.TestCase):
         """)
     expected_formatted_code = textwrap.dedent("""\
         a = line_to_format
+
+
         def f():
             x = y + 42; z = n * 42
             if True: a += 1 ; b += 1 ; c += 1
@@ -797,6 +799,8 @@ class CommandLineTest(unittest.TestCase):
         ''')
     expected_formatted_code = textwrap.dedent('''\
         foo = 42
+
+
         def f():
             email_text += """<html>This is a really long docstring that goes over the column limit and is multi-line.<br><br>
         <b>Czar: </b>"""+despot["Nicholas"]+"""<br>
@@ -1041,6 +1045,7 @@ class CommandLineTest(unittest.TestCase):
         """)
     expected_formatted_code = textwrap.dedent("""\
         def foo():
+
           def bar():
             return {msg_id: author for author, msg_id in reader}
         """)


### PR DESCRIPTION
This allows YAPF to have the correct line counts in most cases. Namely
lines can be deleted only if they are in the range, but if either side
of a range needs correcting of blank lines more lines can be inserted to
get to the correct number.