### PR TITLE
Add quiet flag and return value if quiet

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,11 +2,15 @@
 # All notable changes to this project will be documented in this file.
 # This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.28.1] UNRELEASED
+## [0.29.0] UNRELEASED
+### Added
+- Add the `--quiet` flag to suppress output. The return code is 1 if there are
+  changes, similarly to the `--diff` flag.
 ### Changed
 - Collect a parameter list into a single object. This allows us to track how a
   parameter list is formatted, keeping state along the way. This helps when
   supporting Python 3 type annotations.
+- Catch and report `UnicodeDecodeError` exceptions.
 ### Fixed
 - Format subscript lists so that splits are essentially free after a comma.
 - Don't add a space between a string and its subscript.
@@ -24,7 +28,6 @@
 ### Changed
 - Set `INDENT_DICTIONARY_VALUE` for Google style.
 - Set `JOIN_MULTIPLE_LINES = False` for Google style.
-- Catch and report `UnicodeDecodeError` exceptions.
 ### Fixed
 - `BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF=False` wasn't honored because the
   number of newlines was erroneously calculated beforehand.

--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -267,9 +267,8 @@ def FormatFiles(filenames,
     with concurrent.futures.ProcessPoolExecutor(workers) as executor:
       future_formats = [
           executor.submit(_FormatFile, filename, lines, style_config,
-                          no_local_style, in_place, print_diff, verify,
-                          quiet, verbose)
-          for filename in filenames
+                          no_local_style, in_place, print_diff, verify, quiet,
+                          verbose) for filename in filenames
       ]
       for future in concurrent.futures.as_completed(future_formats):
         changed |= future.result()

--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -290,7 +290,7 @@ def _FormatFile(filename,
                 quiet=False,
                 verbose=False):
   """Format an individual file."""
-  if verbose:
+  if verbose and not quiet:
     print('Reformatting %s' % filename)
   if style_config is None and not no_local_style:
     style_config = file_resources.GetDefaultStyleForDir(


### PR DESCRIPTION
Adds a quiet flag to the command line that suppresses output and sets a return value. This could be useful for performing checks in CI prior to running tests.

Fixes Issue #433 