### PR TITLE
Make COALESCE_BRACKETS and DEDENT_CLOSING_BRACKETS work together

### DIFF
--- a/yapf/yapflib/format_decision_state.py
+++ b/yapf/yapflib/format_decision_state.py
@@ -502,11 +502,7 @@ class FormatDecisionState(object):
       self.stack[-1].closing_scope_indent = max(
           0, self.stack[-1].indent - style.Get('CONTINUATION_INDENT_WIDTH'))
 
-      split_before_closing_bracket = True
-      if style.Get('COALESCE_BRACKETS'):
-        split_before_closing_bracket = False
-
-      self.stack[-1].split_before_closing_bracket = split_before_closing_bracket
+      self.stack[-1].split_before_closing_bracket = True
 
     # Calculate the split penalty.
     penalty = current.split_penalty

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -2266,23 +2266,26 @@ xxxxxxxxxxx, yyyyyyyyyyyy, vvvvvvvvv)
           style.CreateStyleFromConfig(
               '{based_on_style: chromium, coalesce_brackets: True}'))
       unformatted_code = textwrap.dedent("""\
-          date_time_values = {
+          date_time_values = (
+              {
+                  u'year': year,
+                  u'month': month,
+                  u'day_of_month': day_of_month,
+                  u'hours': hours,
+                  u'minutes': minutes,
+                  u'seconds': seconds
+              }
+          )
+          """)
+      expected_formatted_code = textwrap.dedent("""\
+          date_time_values = ({
               u'year': year,
               u'month': month,
               u'day_of_month': day_of_month,
               u'hours': hours,
               u'minutes': minutes,
               u'seconds': seconds
-          }
-          """)
-      expected_formatted_code = textwrap.dedent("""\
-          date_time_values = {
-              u'year': year,
-              u'month': month,
-              u'day_of_month': day_of_month,
-              u'hours': hours,
-              u'minutes': minutes,
-              u'seconds': seconds}
+          })
           """)
       uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
       self.assertCodeEqual(expected_formatted_code,

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -1017,20 +1017,22 @@ class CommandLineTest(unittest.TestCase):
 
   def testCoalesceBrackets(self):
     unformatted_code = textwrap.dedent("""\
-       some_long_function_name_foo({
-           'first_argument_of_the_thing': id,
-           'second_argument_of_the_thing': "some thing"}
-           )""")
+       some_long_function_name_foo(
+           {
+               'first_argument_of_the_thing': id,
+               'second_argument_of_the_thing': "some thing"
+           }
+       )""")
     expected_formatted_code = textwrap.dedent("""\
        some_long_function_name_foo({
            'first_argument_of_the_thing': id,
-           'second_argument_of_the_thing': "some thing"})
+           'second_argument_of_the_thing': "some thing"
+       })
        """)
     with utils.NamedTempFile(dirname=self.test_tmpdir, mode='w') as (f, name):
       f.write(
           textwrap.dedent(u'''\
           [style]
-          based_on_style = facebook
           column_limit=82
           coalesce_brackets = True
           '''))


### PR DESCRIPTION
Attempt to address #432 

The tests for COALESCE_BRACKETS seem wrong to me: 
 * the example code in `yapftests/reformatter_basic_test.py` only has single brackets, with a new line and  dedented closing bracket. And the expected output demonstrates the removal of the newline, rather than coalesced brackets.
 * and while the integration tests in `yapftests/yapf_test.py` do demonstrate `COALESCE_BRACKETS`, the use of facebook base style, hides the bug, where `COALESCE_BRACKETS` overrides the `DEDENT_CLOSING_BRACKETS` behaviour.

I'm tempted to write more tests for the combination of those two options, or to add a argparse assertion to raise an error when `DEDENT_CLOSING_BRACKETS=False` is combined with `COALESCE_BRACKETS=True`; since that the README implies that `COALESCE_BRACKETS` does not apply in that case:

```
``COALESCE_BRACKETS``
    Do not split consecutive brackets. Only relevant when
    ``DEDENT_CLOSING_BRACKETS`` is set. For example:
```

