### PR TITLE
fix FormatFile return value in print mode

### DIFF
--- a/yapf/yapflib/yapf_api.py
+++ b/yapf/yapflib/yapf_api.py
@@ -152,7 +152,7 @@ def FormatCode(unformatted_source,
       unformatted_source, reformatted_source, filename=filename)
 
   if print_diff:
-    return code_diff, code_diff
+    return code_diff, True
 
   return reformatted_source, True
 


### PR DESCRIPTION
API expects `yapf_api.FormatFile` to return a couple `(diff, changed)`
where `changed` must be a boolean.

If `changed` is not a boolean, it then breaks on:
```
  changed |= _FormatFile(...)
```