### PR TITLE
Add verbose flag to print out filenames as they are processed

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,7 @@
 ### Changed
 - Adjust blank lines on formatting boundaries when using the `--lines` option.
 - Return 1 if a diff changed the code. This is in line with how GNU diff acts.
+- Add `-vv` flag to print out file names as they are processed
 ### Fixed
 - Corrected how `DEDENT_CLOSING_BRACKETS` and `COALESCE_BRACKETS` interacted.
 - Fix return value to return a boolean.

--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -233,8 +233,7 @@ def FormatFiles(filenames,
     with concurrent.futures.ProcessPoolExecutor(workers) as executor:
       future_formats = [
           executor.submit(_FormatFile, filename, lines, style_config,
-                          no_local_style, in_place, print_diff, verify,
-                          verbose)
+                          no_local_style, in_place, print_diff, verify, verbose)
           for filename in filenames
       ]
       for future in concurrent.futures.as_completed(future_formats):
@@ -254,7 +253,6 @@ def _FormatFile(filename,
                 print_diff=False,
                 verify=True,
                 verbose=False):
-  logging.info('Reformatting %s', filename)
   if verbose:
     print('Reformatting %s' % filename)
   if style_config is None and not no_local_style:

--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -119,6 +119,11 @@ def main(argv):
       action='store_true',
       help=('Run yapf in parallel when formatting multiple files. Requires '
             'concurrent.futures in Python 2.X'))
+  parser.add_argument(
+      '-vv',
+      '--verbose',
+      action='store_true',
+      help='Print out file names while processing')
 
   parser.add_argument('files', nargs='*')
   args = parser.parse_args(argv[1:])
@@ -185,7 +190,8 @@ def main(argv):
       in_place=args.in_place,
       print_diff=args.diff,
       verify=args.verify,
-      parallel=args.parallel)
+      parallel=args.parallel,
+      verbose=args.verbose)
   return 1 if changed and args.diff else 0
 
 
@@ -196,7 +202,8 @@ def FormatFiles(filenames,
                 in_place=False,
                 print_diff=False,
                 verify=True,
-                parallel=False):
+                parallel=False,
+                verbose=False):
   """Format a list of files.
 
   Arguments:
@@ -213,6 +220,7 @@ def FormatFiles(filenames,
       diff that turns the formatted source into reformatter source.
     verify: (bool) True if reformatted code should be verified for syntax.
     parallel: (bool) True if should format multiple files in parallel.
+    verbose: (bool) True if should print out filenames while processing.
 
   Returns:
     True if the source code changed in any of the files being formatted.
@@ -225,7 +233,8 @@ def FormatFiles(filenames,
     with concurrent.futures.ProcessPoolExecutor(workers) as executor:
       future_formats = [
           executor.submit(_FormatFile, filename, lines, style_config,
-                          no_local_style, in_place, print_diff, verify)
+                          no_local_style, in_place, print_diff, verify,
+                          verbose)
           for filename in filenames
       ]
       for future in concurrent.futures.as_completed(future_formats):
@@ -233,7 +242,7 @@ def FormatFiles(filenames,
   else:
     for filename in filenames:
       changed |= _FormatFile(filename, lines, style_config, no_local_style,
-                             in_place, print_diff, verify)
+                             in_place, print_diff, verify, verbose)
   return changed
 
 
@@ -243,8 +252,11 @@ def _FormatFile(filename,
                 no_local_style=False,
                 in_place=False,
                 print_diff=False,
-                verify=True):
+                verify=True,
+                verbose=False):
   logging.info('Reformatting %s', filename)
+  if verbose:
+    print('Reformatting %s' % filename)
   if style_config is None and not no_local_style:
     style_config = (
         file_resources.GetDefaultStyleForDir(os.path.dirname(filename)))


### PR DESCRIPTION
I didn't see a way to print out filenames as they are processed, so I decided to add `-vv` flag