### PR TITLE
Treat 'async def' like 'def'

### DIFF
--- a/yapf/yapflib/format_decision_state.py
+++ b/yapf/yapflib/format_decision_state.py
@@ -180,7 +180,7 @@ class FormatDecisionState(object):
     # Prevent splitting before the first argument in compound statements
     # with the exception of function declarations.
     if (style.Get('SPLIT_BEFORE_FIRST_ARGUMENT') and
-        self.line.first.value != 'def' and
+        not _IsDefStatement(self.line.first) and
         _IsCompoundStatement(self.line.first)):
       return False
 
@@ -720,6 +720,12 @@ def _IsCompoundStatement(token):
   if token.value == 'async':
     token = token.next_token
   return token.value in _COMPOUND_STMTS
+
+
+def _IsDefStatement(token):
+  if token.value == 'async':
+    token = token.next_token
+  return token.value == 'def'
 
 
 def _IsFunctionCallWithArguments(token):

--- a/yapftests/reformatter_python3_test.py
+++ b/yapftests/reformatter_python3_test.py
@@ -116,6 +116,31 @@ class TestsForPython3Code(yapf_test_helper.YAPFTest):
     uwlines = yapf_test_helper.ParseAndUnwrap(code)
     self.assertCodeEqual(code, reformatter.Reformat(uwlines, verify=False))
 
+  def testAsyncDefSplitBeforeFirstArgument(self):
+    # https://github.com/google/yapf/issues/458
+    if sys.version_info[1] < 5:
+      return
+    try:
+      style.SetGlobalStyle(
+          style.CreateStyleFromConfig(
+              '{based_on_style: pep8, SPLIT_BEFORE_FIRST_ARGUMENT: True}'))
+      code = textwrap.dedent("""\
+      async def open_file(
+              file,
+              mode='r',
+              buffering=-1,
+              encoding=None,
+              errors=None,
+              newline=None,
+              closefd=True,
+              opener=None):
+          pass
+      """)
+      uwlines = yapf_test_helper.ParseAndUnwrap(code)
+      self.assertCodeEqual(code, reformatter.Reformat(uwlines, verify=False))
+    finally:
+      style.SetGlobalStyle(style.CreatePEP8Style())
+
   def testNoSpacesAroundPowerOparator(self):
     try:
       style.SetGlobalStyle(


### PR DESCRIPTION
yapf has special treatment for (a) compound statements, and (b)
compound statements that are not 'def' statements. So you would expect
that 'async def' would be in category (a), but not in category (b).

Originally, 'async def' was not in either category, but this was fixed
in 6412ce704a8f, which made 'async def' (and other async constructs)
treated like compound statements. However, the special check for 'def'
statements was *not* extended to 'async def', so now 'async def' was
in categories (a) *and* (b).

This commit fixes that, so that 'async def' is in category (a) but not
category (b).

Fixes gh-458