### PR TITLE
Make async formatting more intelligent

### DIFF
--- a/yapf/yapflib/reformatter.py
+++ b/yapf/yapflib/reformatter.py
@@ -435,6 +435,13 @@ ONE_BLANK_LINE = 2
 TWO_BLANK_LINES = 3
 
 
+def _IsClassOrDef(uwline):
+  if uwline.first.value in {'class', 'def'}:
+    return True
+
+  return (t.name for t in uwline.tokens[:2]) == ('async', 'def')
+
+
 def _CalculateNumberOfNewlines(first_token, indent_depth, prev_uwline,
                                final_lines):
   """Calculate the number of newlines we need to add.
@@ -507,7 +514,7 @@ def _CalculateNumberOfNewlines(first_token, indent_depth, prev_uwline,
             pytree_utils.SetNodeAnnotation(
                 first_token.node, pytree_utils.Annotation.NEWLINES, None)
           return NO_BLANK_LINES
-    elif prev_uwline.first.value in {'class', 'def', 'async'}:
+    elif _IsClassOrDef(prev_uwline):
       if not style.Get('BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF'):
         pytree_utils.SetNodeAnnotation(first_token.node,
                                        pytree_utils.Annotation.NEWLINES, None)

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -2328,6 +2328,27 @@ s = 'foo \\
     finally:
       style.SetGlobalStyle(style.CreateChromiumStyle())
 
+  def testAsyncAsNonKeyword(self):
+    try:
+      style.SetGlobalStyle(style.CreatePEP8Style())
+
+      # In Python 2, async may be used as a non-keyword identifier.
+      code = textwrap.dedent("""\
+          from util import async
+
+
+          class A(object):
+              def foo(self):
+                  async.run()
+
+              def bar(self):
+                  pass
+          """)
+      uwlines = yapf_test_helper.ParseAndUnwrap(code)
+      self.assertCodeEqual(code, reformatter.Reformat(uwlines, verify=False))
+    finally:
+      style.SetGlobalStyle(style.CreateChromiumStyle())
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Before Python 3.5, async was not a keyword. The formatting of Python 2
code that uses async as a module name, for example, should not treat
async as a keyword.