### PR TITLE
Fix checking for 'async def'

### DIFF
--- a/yapf/yapflib/reformatter.py
+++ b/yapf/yapflib/reformatter.py
@@ -439,7 +439,7 @@ def _IsClassOrDef(uwline):
   if uwline.first.value in {'class', 'def'}:
     return True
 
-  return (t.name for t in uwline.tokens[:2]) == ('async', 'def')
+  return [t.value for t in uwline.tokens[:2]] == ['async', 'def']
 
 
 def _CalculateNumberOfNewlines(first_token, indent_depth, prev_uwline,

--- a/yapftests/reformatter_python3_test.py
+++ b/yapftests/reformatter_python3_test.py
@@ -209,6 +209,17 @@ class TestsForPython3Code(yapf_test_helper.YAPFTest):
     uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
     self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
 
+  def testAsyncFunctionsNested(self):
+    if sys.version_info[1] < 5:
+      return
+    code = textwrap.dedent("""\
+        async def outer():
+            async def inner():
+                pass
+        """)
+    uwlines = yapf_test_helper.ParseAndUnwrap(code)
+    self.assertCodeEqual(code, reformatter.Reformat(uwlines))
+
   def testKeepTypesIntact(self):
     if sys.version_info[1] < 5:
       return


### PR DESCRIPTION
The old code was comparing a generator object against a tuple, which
will never be true. Also it was using token.name, instead of
token.value, for some reason.

Fixes #484