### PR TITLE
Flip INDENT_DICTIONARY_VALUE for Facebook style

### DIFF
--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -308,6 +308,7 @@ def CreateFacebookStyle():
   style['ALIGN_CLOSING_BRACKET_WITH_VISUAL_INDENT'] = False
   style['COLUMN_LIMIT'] = 80
   style['DEDENT_CLOSING_BRACKETS'] = True
+  style['INDENT_DICTIONARY_VALUE'] = True
   style['JOIN_MULTIPLE_LINES'] = False
   style['SPACES_BEFORE_COMMENT'] = 2
   style['SPLIT_PENALTY_AFTER_OPENING_BRACKET'] = 0


### PR DESCRIPTION
With INDENT_DICTIONARY_VALUE=False the dictionaries with long values are formatted in a very bad way

`cat test.py`

    conf = {
        'first_key': True,
        'second_key': [],
        'third_key': 'Beautiful is better than ugly.'
                     'Explicit is better than implicit.'
                     'Simple is better than complex.'
                     'Complex is better than complicated.'
    }

`cat style.yapf`

    [style]
    BASED_ON_STYLE=pep8

`yapf test.py`

    conf = {
        'first_key':
        True,
        'second_key': [],
        'third_key':
        'Beautiful is better than ugly.'
        'Explicit is better than implicit.'
        'Simple is better than complex.'
        'Complex is better than complicated.'
    }

Notice how the first key/value pair is split into two lines, while the second key/value pair is not. While it's somewhat understandable the way the third key/value pair is treated, there's no sensible way to explain the splitting the first key/value pair.

Now when you flip INDENT_DICTIONARY_VALUE:

`cat style.yapf`

    [style]
    BASED_ON_STYLE=pep8
    INDENT_DICTIONARY_VALUE=True

`yapf test.py`

    conf = {
        'first_key': True,
        'second_key': [],
        'third_key': 'Beautiful is better than ugly.'
                     'Explicit is better than implicit.'
                     'Simple is better than complex.'
                     'Complex is better than complicated.'
    }

Much better isn't it?