### PR TITLE
Split vim plugin file into two scripts

### DIFF
--- a/plugins/README.rst
+++ b/plugins/README.rst
@@ -11,8 +11,9 @@ found here: https://github.com/paetzke/py-yapf.el
 VIM
 ===
 
-The ``vim`` plugin allows you to reformat a range of code. Place it into the
-``.vim/autoload`` directory or use a plugin manager like Plug or Vundle:
+The ``vim`` plugin allows you to reformat a range of code. Copy ``plugin`` and
+``autoload`` directories into your ~/.vim or use ``:packadd`` in Vim 8. Or use
+a plugin manager like Plug or Vundle:
 
 .. code-block:: vim
 
@@ -29,6 +30,16 @@ You can add key bindings in the ``.vimrc`` file:
 
     map <C-Y> :call yapf#YAPF()<cr>
     imap <C-Y> <c-o>:call yapf#YAPF()<cr>
+
+Alternatively, you can call the command ``YAPF``. If you omit the range, it
+will reformat the whole buffer.
+
+example:
+
+.. code-block:: vim
+
+    :YAPF       " formats whole buffer
+    :'<,'>YAPF  " formats lines selected in visual mode
 
 Sublime Text
 ============

--- a/plugins/vim/autoload/yapf.vim
+++ b/plugins/vim/autoload/yapf.vim
@@ -20,13 +20,6 @@
 "    map <C-P> :call yapf#YAPF()<cr>
 "    imap <C-P> <c-o>:call yapf#YAPF()<cr>
 "
-" Alternatively, you can call the command YAPF. If you omit the range,
-" it will reformat the whole buffer.
-"
-" example:
-"   :YAPF       " formats whole buffer
-"   :'<,'>YAPF  " formats lines selected in visual mode
-"
 function! yapf#YAPF() range
   " Determine range to format.
   let l:line_ranges = a:firstline . '-' . a:lastline
@@ -54,5 +47,3 @@ function! yapf#YAPF() range
   " Reset cursor to first line of the formatted range.
   call cursor(a:firstline, 1)
 endfunction
-
-command! -range=% YAPF <line1>,<line2>call yapf#YAPF()

--- a/plugins/vim/autoload/yapf.vim
+++ b/plugins/vim/autoload/yapf.vim
@@ -17,8 +17,8 @@
 " Place this script in your ~/.vim/autoload directory. You can add accessors to
 " ~/.vimrc, e.g.:
 "
-"    map <C-P> :call yapf#YAPF()<cr>
-"    imap <C-P> <c-o>:call yapf#YAPF()<cr>
+"    map <C-Y> :call yapf#YAPF()<cr>
+"    imap <C-Y> <c-o>:call yapf#YAPF()<cr>
 "
 function! yapf#YAPF() range
   " Determine range to format.

--- a/plugins/vim/plugin/yapf.vim
+++ b/plugins/vim/plugin/yapf.vim
@@ -1,0 +1,25 @@
+" Copyright 2015 Google Inc. All Rights Reserved.
+"
+" Licensed under the Apache License, Version 2.0 (the "License");
+" you may not use this file except in compliance with the License.
+" You may obtain a copy of the License at
+"
+"     http://www.apache.org/licenses/LICENSE-2.0
+"
+" Unless required by applicable law or agreed to in writing, software
+" distributed under the License is distributed on an "AS IS" BASIS,
+" WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+" See the License for the specific language governing permissions and
+" limitations under the License.
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" VIM command for YAPF support
+"
+" Place this script in your ~/.vim/plugin directory. You can call the
+" command YAPF. If you omit the range, it will reformat the whole
+" buffer.
+"
+" example:
+"   :YAPF       " formats whole buffer
+"   :'<,'>YAPF  " formats lines selected in visual mode
+
+command! -range=% YAPF <line1>,<line2>call yapf#YAPF()


### PR DESCRIPTION
Have you ever tested the plugin under Vim 8?
An error of `E492: Not an editor command: YAPF` will arise when you type in `:YAPF`.
It seems that commands can't be defined in autoload script in Vim 8. This PR will fix the command issue in Vim 8.
FYI. If this PR is going to be merged, I've signed the CLA.