### PR TITLE
Fix formatting with use_tabs=True.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@
 ## [0.20.1] UNRELEASED
 ### Fixed
 - Don't treat 'None' as a keyword if calling a function on it, like '__ne__()'.
+- use_tabs=True always uses a single tab per indentation level; spaces are
+  used for aligning vertically after that.
 
 ## [0.20.0] 2017-11-14
 ### Added

--- a/yapf/yapflib/format_token.py
+++ b/yapf/yapflib/format_token.py
@@ -122,11 +122,11 @@ class FormatToken(object):
       spaces: (int) The number of spaces to place before the token.
       indent_level: (int) The indentation level.
     """
-    indent_char = '\t' if style.Get('USE_TABS') else ' '
-    token_indent_char = indent_char if newlines_before > 0 else ' '
-    indent_before = (
-        indent_char * indent_level * style.Get('INDENT_WIDTH') +
-        token_indent_char * spaces)
+    if style.Get('USE_TABS'):
+      indent_before = '\t' * indent_level + ' ' * spaces
+    else:
+      indent_before = (
+          ' ' * indent_level * style.Get('INDENT_WIDTH') + ' ' * spaces)
 
     if self.is_comment:
       comment_lines = [s.lstrip() for s in self.value.splitlines()]


### PR DESCRIPTION
There are two issues when setting use_tabs=True:

1) The indent_width then makes no sense as a single tab per indentation is
   always desired.

2) Aligning things vertically after the indentation should never be done with
   tabs. The current setting assumes that a tab has the same width as a a single
   space and breaks the following code spectacularly:

```
def test():
	my_module.call_function("1234567890", "1234567890", "1234567890", "1234567890", "1234567890")
```

with style

````
[style]
# The number of columns to use for indentation.
indent_width=1
# Use the Tab character for indentation.
use_tabs=True
````

For example, clang-format still uses spaces for vertical alignment when using
tabs for indentation.