### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,7 +12,7 @@
 - use_tabs=True always uses a single tab per indentation level; spaces are
   used for aligning vertically after that.
 - Relax the split of a paren at the end of an if statement. With
-  `dedent_closing_brackets` option requires that it be able to split there. 
+  `dedent_closing_brackets` option requires that it be able to split there.
 
 ## [0.20.0] 2017-11-14
 ### Added
@@ -95,7 +95,7 @@
 
 ## [0.16.3] 2017-07-13
 ### Changed
-- Add filename information to a ParseError excetion.
+- Add filename information to a ParseError exception.
 ### Fixed
 - A token that ends in a continuation marker may have more than one newline in
   it, thus changing its "lineno" value. This can happen if multiple
@@ -180,7 +180,7 @@
 ## [0.15.0] 2017-01-12
 ### Added
 - Keep type annotations intact as much as possible. Don't try to split the over
-  mutliple lines.
+  multiple lines.
 ### Fixed
 - When determining if each element in a dictionary can fit on a single line, we
   are skipping dictionary entries. However, we need to ignore comments in our

--- a/HACKING.rst
+++ b/HACKING.rst
@@ -5,7 +5,7 @@ To run YAPF on all of YAPF::
 
  $ PYTHONPATH=$PWD/yapf python -m yapf -i -r .
 
-To run YAPF on just the files changed in the curent git branch::
+To run YAPF on just the files changed in the current git branch::
 
  $ PYTHONPATH=$PWD/yapf python -m yapf -i $(git diff --name-only @{upstream})
 

--- a/README.rst
+++ b/README.rst
@@ -466,7 +466,7 @@ Knobs
 
 ``SPLIT_COMPLEX_COMPREHENSION``
     For list comprehensions and generator expressions with multiple clauses
-    (e.g mutiple "for" calls, "if" filter expressions) and which need to be
+    (e.g multiple "for" calls, "if" filter expressions) and which need to be
     reflowed, split each clause onto its own line. For example:
 
     .. code-block:: python

--- a/yapf/yapflib/continuation_splicer.py
+++ b/yapf/yapflib/continuation_splicer.py
@@ -16,7 +16,7 @@
 The "backslash-newline" continuation marker is shoved into the node's prefix.
 Pull them out and make it into nodes of their own.
 
-  SpliceContinuations(): the main funciton exported by this module.
+  SpliceContinuations(): the main function exported by this module.
 """
 
 from lib2to3 import pytree

--- a/yapf/yapflib/format_decision_state.py
+++ b/yapf/yapflib/format_decision_state.py
@@ -798,7 +798,7 @@ class FormatDecisionState(object):
              format_token.Subtype.DICTIONARY_VALUE in current.subtypes) or
             ImplicitStringConcatenation(current)):
           # A dictionary entry that cannot fit on a single line shouldn't matter
-          # to this calcuation. If it can't fit on a single line, then the
+          # to this calculation. If it can't fit on a single line, then the
           # opening should be on the same line as the key and the rest on
           # newlines after it. But the other entries should be on single lines
           # if possible.

--- a/yapf/yapflib/split_penalty.py
+++ b/yapf/yapflib/split_penalty.py
@@ -192,7 +192,7 @@ class _SplitPenaltyAssigner(pytree_visitor.PyTreeVisitor):
         _SetStronglyConnected(node.children[1])
         if (len(node.children[1].children) > 1 and
             pytree_utils.NodeName(node.children[1].children[1]) == 'comp_for'):
-          # Don't penalize spliting before a comp_for expression.
+          # Don't penalize splitting before a comp_for expression.
           _SetSplitPenalty(_FirstChildNode(node.children[1]), 0)
         else:
           _SetSplitPenalty(

--- a/yapf/yapflib/unwrapped_line.py
+++ b/yapf/yapflib/unwrapped_line.py
@@ -282,7 +282,7 @@ def _SpaceRequiredBetween(left, right):
       # or dot should have a space after it.
       return True
   if left.is_binary_op and lval != '**' and _IsUnaryOperator(right):
-    # Space between the binary opertor and the unary operator.
+    # Space between the binary operator and the unary operator.
     return True
   if left.is_keyword and _IsUnaryOperator(right):
     # Handle things like "not -3 < x".
@@ -324,7 +324,7 @@ def _SpaceRequiredBetween(left, right):
     return False
   if ((lval == '(' and rval == ')') or (lval == '[' and rval == ']') or
       (lval == '{' and rval == '}')):
-    # Empty objects shouldn't be separted by spaces.
+    # Empty objects shouldn't be separated by spaces.
     return False
   if (lval in pytree_utils.OPENING_BRACKETS and
       rval in pytree_utils.OPENING_BRACKETS):

--- a/yapf/yapflib/yapf_api.py
+++ b/yapf/yapflib/yapf_api.py
@@ -68,7 +68,7 @@ def FormatFile(filename,
 
   Returns:
     Tuple of (reformatted_code, encoding, changed). reformatted_code is None if
-    the file is sucessfully written to (having used in_place). reformatted_code
+    the file is successfully written to (having used in_place). reformatted_code
     is a diff if print_diff is True.
 
   Raises:

--- a/yapftests/reformatter_pep8_test.py
+++ b/yapftests/reformatter_pep8_test.py
@@ -88,7 +88,7 @@ class TestsForPEP8Style(yapf_test_helper.YAPFTest):
     uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
     self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
 
-  def testContinuedNonOudentedLine(self):
+  def testContinuedNonOutdentedLine(self):
     code = textwrap.dedent("""\
         class eld(d):
             if str(geom.geom_type).upper(

--- a/yapftests/reformatter_python3_test.py
+++ b/yapftests/reformatter_python3_test.py
@@ -116,7 +116,7 @@ class TestsForPython3Code(yapf_test_helper.YAPFTest):
     uwlines = yapf_test_helper.ParseAndUnwrap(code)
     self.assertCodeEqual(code, reformatter.Reformat(uwlines, verify=False))
 
-  def testNoSpacesAroundPowerOparator(self):
+  def testNoSpacesAroundPowerOperator(self):
     try:
       style.SetGlobalStyle(
           style.CreateStyleFromConfig(

--- a/yapftests/utils.py
+++ b/yapftests/utils.py
@@ -34,13 +34,13 @@ def stdout_redirector(stream):  # pylint: disable=invalid-name
 # NamedTemporaryFile is useless because on Windows the temporary file would be
 # created with O_TEMPORARY, which would not allow the file to be opened a
 # second time, even by the same process, unless the same flag is used.
-# Thus we provide a simplifed version ourselfs.
+# Thus we provide a simplified version ourselves.
 #
 # Note: returns a tuple of (io.file_obj, file_path), instead of a file_obj with
 # a .name attribute
 #
 # Note: `buffering` is set to -1 despite documentation of NamedTemporaryFile
-# says None. This is probably a problem with the python documenation.
+# says None. This is probably a problem with the python documentation.
 @contextlib.contextmanager
 def NamedTempFile(mode='w+b',
                   buffering=-1,


### PR DESCRIPTION
old | new
:---: | :---:
  `funciton` | `function`
  `calcuation` | `calculation`
  `spliting` | `splitting`
  `opertor` | `operator`
  `separted` | `separated`
  `sucessfully` | `successfully`
  `Oudented` | `Outdented`
  `Oparator` | `Operator`
  `simplifed` | `simplified`
  `ourselfs` | `ourselves`
  `documenation` | `documentation`
  `excetion` | `exception`
  `mutliple` | `multiple`
  `curent` | `current`
  `mutiple` | `multiple`