### PR TITLE
Allow single-line dictionaries.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@
 # This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.20.2] UNRELEASED
+### Changed
+- Allow dictionaries to stay on a single line if they only have one entry
 ### Fixed
 - Use tabs when constructing a continuation line when `USE_TABS` is enabled.
 

--- a/yapf/yapflib/format_decision_state.py
+++ b/yapf/yapflib/format_decision_state.py
@@ -293,14 +293,13 @@ class FormatDecisionState(object):
           # This is a dictionary that's an argument to a function.
           if (self._FitsOnLine(previous, previous.matching_bracket) and
               previous.matching_bracket.next_token and
-              not previous.matching_bracket.next_token.ClosesScope() and
               (not opening.matching_bracket.next_token or
-               opening.matching_bracket.next_token.value != '.')):
+               opening.matching_bracket.next_token.value != '.') and
+              _ScopeHasNoCommas(previous)):
             # Don't split before the key if:
             #   - The dictionary fits on a line, and
-            #   - The dictionary brackets don't have a closing scope after
-            #     them, and
-            #   - The function call isn't part of a builder-style call.
+            #   - The function call isn't part of a builder-style call and
+            #   - The dictionary has one entry and no trailing comma
             return False
       return True
 
@@ -929,6 +928,19 @@ def _IsSingleElementTuple(token):
     else:
       token = token.next_token
   return num_commas == 1
+
+
+def _ScopeHasNoCommas(token):
+  close = token.matching_bracket
+  token = token.next_token
+  while token != close:
+    if token.value == ',':
+      return False
+    if token.OpensScope():
+      token = token.matching_bracket
+    else:
+      token = token.next_token
+  return True
 
 
 class _ParenState(object):

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -2116,7 +2116,7 @@ s = 'foo \\
         class _():
 
           @mock.patch.dict(
-              os.environ, 
+              os.environ,
               {'HTTP_' + xsrf._XSRF_TOKEN_HEADER.replace('-', '_'): 'atoken'})
           def _():
             pass

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -2115,9 +2115,9 @@ s = 'foo \\
     code = textwrap.dedent("""\
         class _():
 
-          @mock.patch.dict(os.environ, {
-              'HTTP_' + xsrf._XSRF_TOKEN_HEADER.replace('-', '_'): 'atoken'
-          })
+          @mock.patch.dict(
+              os.environ, {
+              'HTTP_' + xsrf._XSRF_TOKEN_HEADER.replace('-', '_'): 'atoken'})
           def _():
             pass
 

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -2116,8 +2116,8 @@ s = 'foo \\
         class _():
 
           @mock.patch.dict(
-              os.environ, {
-              'HTTP_' + xsrf._XSRF_TOKEN_HEADER.replace('-', '_'): 'atoken'})
+              os.environ, 
+              {'HTTP_' + xsrf._XSRF_TOKEN_HEADER.replace('-', '_'): 'atoken'})
           def _():
             pass
 

--- a/yapftests/reformatter_buganizer_test.py
+++ b/yapftests/reformatter_buganizer_test.py
@@ -1759,6 +1759,6 @@ dddddddddddddddddd().eeeeeeeeeeeeeeeeeeeee().fffffffffffffffff().ggggggggggggggg
     uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
     self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
 
-    
+
 if __name__ == '__main__':
   unittest.main()

--- a/yapftests/reformatter_buganizer_test.py
+++ b/yapftests/reformatter_buganizer_test.py
@@ -53,15 +53,11 @@ def _():
       (Gauge(
           metric='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
           group_by=group_by + ['metric:process_name'],
-          metric_filter={
-              'metric:process_name': process_name_re
-          }),
+          metric_filter={'metric:process_name': process_name_re}),
        Gauge(
            metric='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
            group_by=group_by + ['metric:process_name'],
-           metric_filter={
-               'metric:process_name': process_name_re
-           }))
+           metric_filter={'metric:process_name': process_name_re}))
       | expr.Join(
           left_name='start', left_default=0, right_name='end', right_default=0)
       | m.Point(
@@ -1741,6 +1737,28 @@ dddddddddddddddddd().eeeeeeeeeeeeeeeeeeeee().fffffffffffffffff().ggggggggggggggg
     uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
     self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
 
+  def testB67935687(self):
+    code = textwrap.dedent("""\
+        Fetch(
+            Raw('monarch.BorgTask', '/union/row_operator_action_delay'),
+            {'borg_user': self.borg_user})
+    """)
+    uwlines = yapf_test_helper.ParseAndUnwrap(code)
+    self.assertCodeEqual(code, reformatter.Reformat(uwlines))
 
+    unformatted_code = textwrap.dedent("""\
+        shelf_renderer.expand_text = text.translate_to_unicode(
+            expand_text % {
+                'creator': creator
+            })
+        """)
+    expected_formatted_code = textwrap.dedent("""\
+        shelf_renderer.expand_text = text.translate_to_unicode(
+            expand_text % {'creator': creator})
+        """)
+    uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
+    self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
+
+    
 if __name__ == '__main__':
   unittest.main()

--- a/yapftests/style_test.py
+++ b/yapftests/style_test.py
@@ -225,13 +225,11 @@ class StyleFromDict(unittest.TestCase):
 
   def testDefaultBasedOnStyleBadDict(self):
     self.assertRaisesRegexp(style.StyleConfigError, 'Unknown style option',
-                            style.CreateStyleFromConfig, {
-                                'based_on_styl': 'pep8'
-                            })
+                            style.CreateStyleFromConfig,
+                            {'based_on_styl': 'pep8'})
     self.assertRaisesRegexp(style.StyleConfigError, 'not a valid',
-                            style.CreateStyleFromConfig, {
-                                'INDENT_WIDTH': 'FOUR'
-                            })
+                            style.CreateStyleFromConfig,
+                            {'INDENT_WIDTH': 'FOUR'})
 
 
 class StyleFromCommandLine(unittest.TestCase):

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -1296,9 +1296,7 @@ INDENT_WIDTH=1
     self.assertYapfReformats(
         unformatted_code,
         expected_formatted_code,
-        env={
-            'PYTHONIOENCODING': 'cp936'
-        })
+        env={'PYTHONIOENCODING': 'cp936'})
 
 
 class BadInputTest(unittest.TestCase):


### PR DESCRIPTION
Change formatting of dictionaries to allow them to remain on one line if they only have one entry and it wouldn't violate character limits.