### PR TITLE
get the default style when the --style-help flag is passed

### DIFF
--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -133,8 +133,12 @@ def main(argv):
     print('yapf {}'.format(__version__))
     return 0
 
+  style_config = args.style
+
   if args.style_help:
-    style.SetGlobalStyle(style.CreateStyleFromConfig(args.style))
+    if style_config is None and not args.no_local_style:
+        style_config = file_resources.GetDefaultStyleForDir(os.getcwd())
+    style.SetGlobalStyle(style.CreateStyleFromConfig(style_config))
     print('[style]')
     for option, docstring in sorted(style.Help().items()):
       for line in docstring.splitlines():
@@ -166,7 +170,6 @@ def main(argv):
       except EOFError:
         break
 
-    style_config = args.style
     if style_config is None and not args.no_local_style:
       style_config = file_resources.GetDefaultStyleForDir(os.getcwd())
 

--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -137,7 +137,7 @@ def main(argv):
 
   if args.style_help:
     if style_config is None and not args.no_local_style:
-        style_config = file_resources.GetDefaultStyleForDir(os.getcwd())
+      style_config = file_resources.GetDefaultStyleForDir(os.getcwd())
     style.SetGlobalStyle(style.CreateStyleFromConfig(style_config))
     print('[style]')
     for option, docstring in sorted(style.Help().items()):


### PR DESCRIPTION
When my `~/.config/yapf/style` looks like:

```
[style]
column_limit = 100
```

and I run `yapf --style-help`, the result contains `column_limit=79`. At first, I thought yapf wasn't recognizing my `~/.config/yapf/style`, but I eventually realized that it was finding it when running on actual files, but not when I passed the `--style-help` flag. This PR fixes this issue, allowing one to use `yapf --style-help` to confirm that one's global config file is being recognized.