### PR TITLE
Introduce a SPLIT_BEFORE_ENDING_BRACKET knob

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,12 @@
 # All notable changes to this project will be documented in this file.
 # This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.20.3] UNRELEASED
+### Added
+- Introduce a new option of formatting multiline literals. Add
+  `SPLIT_BEFORE_CLOSING_BRACKET` knob to control whether closing bracket should
+  get their own line.
+
 ## [0.20.2] 2018-02-12
 ### Changed
 - Improve the speed at which files are excluded by ignoring them earlier.

--- a/README.rst
+++ b/README.rst
@@ -439,6 +439,10 @@ Knobs
     Set to ``True`` to prefer splitting before ``&``, ``|`` or ``^`` rather
     than after.
 
+``SPLIT_BEFORE_CLOSING_BRACKET``
+    Split before the closing bracket if a list or dict literal doesn't fit on
+    a single line.
+
 ``SPLIT_BEFORE_DICT_SET_GENERATOR``
     Split before a dictionary or set generator (comp_for). For example, note
     the split before the ``for``:

--- a/yapf/yapflib/format_decision_state.py
+++ b/yapf/yapflib/format_decision_state.py
@@ -177,7 +177,8 @@ class FormatDecisionState(object):
     if not previous:
       return False
 
-    if self.stack[-1].split_before_closing_bracket and current.value in '}]':
+    if (self.stack[-1].split_before_closing_bracket and
+        current.value in '}]' and style.Get('SPLIT_BEFORE_CLOSING_BRACKET')):
       # Split before the closing bracket if we can.
       return current.node_split_penalty != split_penalty.UNBREAKABLE
 

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -158,6 +158,9 @@ _STYLE_HELP = dict(
     SPLIT_BEFORE_BITWISE_OPERATOR=textwrap.dedent("""\
       Set to True to prefer splitting before '&', '|' or '^' rather than
       after."""),
+    SPLIT_BEFORE_CLOSING_BRACKET=textwrap.dedent("""\
+      Split before the closing bracket if a list or dict literal doesn't fit on
+      a single line."""),
     SPLIT_BEFORE_DICT_SET_GENERATOR=textwrap.dedent("""\
       Split before a dictionary or set generator (comp_for). For example, note
       the split before the 'for':
@@ -257,6 +260,7 @@ def CreatePEP8Style():
       SPACES_BEFORE_COMMENT=2,
       SPLIT_ARGUMENTS_WHEN_COMMA_TERMINATED=False,
       SPLIT_BEFORE_BITWISE_OPERATOR=True,
+      SPLIT_BEFORE_CLOSING_BRACKET=True,
       SPLIT_BEFORE_DICT_SET_GENERATOR=True,
       SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN=False,
       SPLIT_BEFORE_FIRST_ARGUMENT=False,
@@ -387,6 +391,7 @@ _STYLE_OPTION_VALUE_CONVERTER = dict(
     SPACES_BEFORE_COMMENT=int,
     SPLIT_ARGUMENTS_WHEN_COMMA_TERMINATED=_BoolConverter,
     SPLIT_BEFORE_BITWISE_OPERATOR=_BoolConverter,
+    SPLIT_BEFORE_CLOSING_BRACKET=_BoolConverter,
     SPLIT_BEFORE_DICT_SET_GENERATOR=_BoolConverter,
     SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN=_BoolConverter,
     SPLIT_BEFORE_FIRST_ARGUMENT=_BoolConverter,


### PR DESCRIPTION
This new knob controls whether closing brackets get a separate line in multiline literals.

The default is enabled:

```python
foo = {
    'a': 1
}
```

However it can now be disabled:

```python
foo = {
    'a': 1}
```