### PR TITLE
Add knob BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@
 - Introduce a new option of formatting multiline literals. Add
   `SPLIT_BEFORE_CLOSING_BRACKET` knob to control whether closing bracket should
   get their own line.
+- Add 'BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION' knob to control the number
+  of blank lines between top-level function and class definitions.
 
 ## [0.20.2] 2018-02-12
 ### Changed

--- a/README.rst
+++ b/README.rst
@@ -325,6 +325,19 @@ Knobs
 ``BLANK_LINE_BEFORE_CLASS_DOCSTRING``
     Insert a blank line before a class-level docstring.
 
+``BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION``
+    Sets the number of desired blank lines surrounding top-level function and
+    class definitions. For example:
+
+    .. code-block:: python
+
+        class Foo:
+            pass
+                           # <------ having two blank lines here
+                           # <------ is the default setting
+        class Bar:
+            pass
+
 ``COALESCE_BRACKETS``
     Do not split consecutive brackets. Only relevant when
     ``DEDENT_CLOSING_BRACKETS`` is set. For example:

--- a/yapf/yapflib/blank_line_calculator.py
+++ b/yapf/yapflib/blank_line_calculator.py
@@ -27,6 +27,7 @@ from lib2to3 import pytree
 from yapf.yapflib import py3compat
 from yapf.yapflib import pytree_utils
 from yapf.yapflib import pytree_visitor
+from yapf.yapflib import style
 
 _NO_BLANK_LINES = 1
 _ONE_BLANK_LINE = 2
@@ -155,7 +156,7 @@ class _BlankLineCalculator(pytree_visitor.PyTreeVisitor):
     if self.last_was_decorator:
       return _NO_BLANK_LINES
     elif self._IsTopLevel(node):
-      return _TWO_BLANK_LINES
+      return 1 + style.Get('BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION')
     return _ONE_BLANK_LINE
 
   def _SetNumNewlines(self, node, num_newlines):

--- a/yapf/yapflib/reformatter.py
+++ b/yapf/yapflib/reformatter.py
@@ -479,9 +479,9 @@ def _CalculateNumberOfNewlines(first_token, indent_depth, prev_uwline,
   prev_last_token = prev_uwline.last
   if prev_last_token.is_docstring:
     if (not indent_depth and first_token.value in {'class', 'def', 'async'}):
-      # Separate a class or function from the module-level docstring with two
-      # blank lines.
-      return TWO_BLANK_LINES
+      # Separate a class or function from the module-level docstring with
+      # appropriate number of blank lines.
+      return 1 + style.Get('BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION')
     if _NoBlankLinesBeforeCurrentToken(prev_last_token.value, first_token,
                                        prev_last_token):
       return NO_BLANK_LINES
@@ -509,7 +509,8 @@ def _CalculateNumberOfNewlines(first_token, indent_depth, prev_uwline,
           if final_lines[index - 1].first.value == '@':
             final_lines[index].first.AdjustNewlinesBefore(NO_BLANK_LINES)
           else:
-            prev_last_token.AdjustNewlinesBefore(TWO_BLANK_LINES)
+            prev_last_token.AdjustNewlinesBefore(
+                1 + style.Get('BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION'))
           if first_token.newlines is not None:
             pytree_utils.SetNodeAnnotation(
                 first_token.node, pytree_utils.Annotation.NEWLINES, None)

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -71,6 +71,9 @@ _STYLE_HELP = dict(
             ..."""),
     BLANK_LINE_BEFORE_CLASS_DOCSTRING=textwrap.dedent("""\
       Insert a blank line before a class-level docstring."""),
+    BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION=textwrap.dedent("""\
+      Number of blank lines surrounding top-level function and class
+      definitions."""),
     COALESCE_BRACKETS=textwrap.dedent("""\
       Do not split consecutive brackets. Only relevant when
       dedent_closing_brackets is set. For example:
@@ -243,6 +246,7 @@ def CreatePEP8Style():
       ALLOW_SPLIT_BEFORE_DICT_VALUE=True,
       BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF=False,
       BLANK_LINE_BEFORE_CLASS_DOCSTRING=False,
+      BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION=2,
       COALESCE_BRACKETS=False,
       COLUMN_LIMIT=79,
       CONTINUATION_INDENT_WIDTH=4,
@@ -374,6 +378,7 @@ _STYLE_OPTION_VALUE_CONVERTER = dict(
     ALLOW_SPLIT_BEFORE_DICT_VALUE=_BoolConverter,
     BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF=_BoolConverter,
     BLANK_LINE_BEFORE_CLASS_DOCSTRING=_BoolConverter,
+    BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION=int,
     COALESCE_BRACKETS=_BoolConverter,
     COLUMN_LIMIT=int,
     CONTINUATION_INDENT_WIDTH=int,


### PR DESCRIPTION
suggested patch for #527 to gauge whether there is any interest in this at all.

If so, need to
- [ ] make sure it actually works
- [ ] add test
- [ ] discuss if there is a nicer way of expressing 1+number_of_lines
- [ ] ...or should it be a "1 or 2" boolean flag instead of an int?