### PR TITLE
Add `CONTINUATION_ALIGNMENT_TYPE` knob to adjust how continuation lines vertically aligned when `USE_TABS` = True

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@
 - Introduce a new option of formatting multiline literals. Add
   `SPLIT_BEFORE_CLOSING_BRACKET` knob to control whether closing bracket should
   get their own line.
+- Added `CONTINUATION_ALIGNMENT_TYPE` knob to choose vertical alignment style
+  when `USE_TABS` is enabled.
 
 ## [0.20.2] 2018-02-12
 ### Changed

--- a/README.rst
+++ b/README.rst
@@ -351,6 +351,21 @@ Knobs
 ``COLUMN_LIMIT``
     The column limit (or max line-length)
 
+``CONTINUATION_ALIGNMENT_TYPE``
+    The style for continuation alignment. Possible values are:
+
+    - SPACE: Use spaces for continuation alignment. This is default behavior.
+    - FIXED: Use fixed number (CONTINUATION_INDENT_WIDTH) of columns
+      (ie: CONTINUATION_INDENT_WIDTH/INDENT_WIDTH tabs) for continuation
+      alignment.
+    - LESS: Slightly left if cannot vertically align continuation lines with
+      indent characters.
+    - MORE: Slightly right if cannot vertically align continuation lines with
+      indent characters.
+
+    For options ``FIXED``, ``LESS`` and ``MORE`` are only available when
+    ``USE_TABS`` is enabled.
+
 ``CONTINUATION_INDENT_WIDTH``
     Indent width used for line continuations.
 

--- a/yapf/yapflib/format_token.py
+++ b/yapf/yapflib/format_token.py
@@ -58,6 +58,29 @@ class Subtype(object):
   TYPED_NAME_ARG_LIST = 20
 
 
+def _TabModeContAlignPadding(spaces):
+  """Build padding string for continuation alignment in tabbed indentation.
+
+  Arguments:
+    spaces: (int) The number of spaces to place before the token for alignment.
+
+  Returns:
+    A string for alignment with style specified by CONTINUATION_ALIGNMENT_TYPE
+    option.
+  """
+  align_type = style.Get('CONTINUATION_ALIGNMENT_TYPE').upper()
+  ts = style.Get('INDENT_WIDTH')
+  if align_type == 'FIXED':
+    if spaces > 0:
+      return '\t' * int(style.Get('CONTINUATION_INDENT_WIDTH') / ts)
+    return ''
+  elif align_type == 'LESS':
+    return '\t' * int(spaces / ts)
+  elif align_type == 'MORE':
+    return '\t' * int((spaces + ts - 1) / ts)
+  return ' ' * spaces
+
+
 class FormatToken(object):
   """A wrapper around pytree Leaf nodes.
 
@@ -123,7 +146,10 @@ class FormatToken(object):
       indent_level: (int) The indentation level.
     """
     if style.Get('USE_TABS'):
-      indent_before = '\t' * indent_level + ' ' * spaces
+      if newlines_before > 0:
+        indent_before = '\t' * indent_level + _TabModeContAlignPadding(spaces)
+      else:
+        indent_before = '\t' * indent_level + ' ' * spaces
     else:
       indent_before = (
           ' ' * indent_level * style.Get('INDENT_WIDTH') + ' ' * spaces)

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -90,6 +90,20 @@ _STYLE_HELP = dict(
          })"""),
     COLUMN_LIMIT=textwrap.dedent("""\
       The column limit."""),
+    CONTINUATION_ALIGNMENT_TYPE=textwrap.dedent("""\
+      The style for continuation alignment. Possible values are:
+
+      - SPACE: Use spaces for continuation alignment. This is default behavior.
+      - FIXED: Use fixed number (CONTINUATION_INDENT_WIDTH) of columns
+        (ie: CONTINUATION_INDENT_WIDTH/INDENT_WIDTH Tabs) for continuation
+        alignment.
+      - LESS: Slightly left if cannot vertically align continuation lines with
+        indent characters.
+      - MORE: Slightly right if cannot vertically align continuation lines with
+        indent characters.
+
+      For options FIXED, LESS and MORE are only available when USE_TABS is
+      enabled."""),
     CONTINUATION_INDENT_WIDTH=textwrap.dedent("""\
       Indent width used for line continuations."""),
     DEDENT_CLOSING_BRACKETS=textwrap.dedent("""\
@@ -245,6 +259,7 @@ def CreatePEP8Style():
       BLANK_LINE_BEFORE_CLASS_DOCSTRING=False,
       COALESCE_BRACKETS=False,
       COLUMN_LIMIT=79,
+      CONTINUATION_ALIGNMENT_TYPE='SPACE',
       CONTINUATION_INDENT_WIDTH=4,
       DEDENT_CLOSING_BRACKETS=False,
       EACH_DICT_ENTRY_ON_SEPARATE_LINE=True,
@@ -376,6 +391,7 @@ _STYLE_OPTION_VALUE_CONVERTER = dict(
     BLANK_LINE_BEFORE_CLASS_DOCSTRING=_BoolConverter,
     COALESCE_BRACKETS=_BoolConverter,
     COLUMN_LIMIT=int,
+    CONTINUATION_ALIGNMENT_TYPE=str,
     CONTINUATION_INDENT_WIDTH=int,
     DEDENT_CLOSING_BRACKETS=_BoolConverter,
     EACH_DICT_ENTRY_ON_SEPARATE_LINE=_BoolConverter,

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -1203,6 +1203,90 @@ INDENT_WIDTH=1
           expected_formatted_code,
           extra_options=['--style={0}'.format(stylepath)])
 
+  def testUseTabsContAlignTypeFixed(self):
+    unformatted_code = """\
+def foo_function(arg1, arg2, arg3):
+  return ['hello', 'world',]
+"""
+    expected_formatted_code = """\
+def foo_function(arg1, arg2,
+		arg3):
+	return [
+			'hello',
+			'world',
+	]
+"""
+    style_contents = u"""\
+[style]
+based_on_style = chromium
+USE_TABS = true
+COLUMN_LIMIT=32
+INDENT_WIDTH=4
+CONTINUATION_INDENT_WIDTH=8
+CONTINUATION_ALIGNMENT_TYPE = fixed
+"""
+    with utils.TempFileContents(self.test_tmpdir, style_contents) as stylepath:
+      self.assertYapfReformats(
+          unformatted_code,
+          expected_formatted_code,
+          extra_options=['--style={0}'.format(stylepath)])
+
+  def testUseTabsContAlignTypeLess(self):
+    unformatted_code = """\
+def foo_function(arg1, arg2, arg3):
+  return ['hello', 'world',]
+"""
+    expected_formatted_code = """\
+def foo_function(arg1, arg2,
+				arg3):
+	return [
+			'hello',
+			'world',
+	]
+"""
+    style_contents = u"""\
+[style]
+based_on_style = chromium
+USE_TABS = true
+COLUMN_LIMIT=32
+INDENT_WIDTH=4
+CONTINUATION_INDENT_WIDTH=8
+CONTINUATION_ALIGNMENT_TYPE = less
+"""
+    with utils.TempFileContents(self.test_tmpdir, style_contents) as stylepath:
+      self.assertYapfReformats(
+          unformatted_code,
+          expected_formatted_code,
+          extra_options=['--style={0}'.format(stylepath)])
+
+  def testUseTabsContAlignTypeMore(self):
+    unformatted_code = """\
+def foo_function(arg1, arg2, arg3):
+  return ['hello', 'world',]
+"""
+    expected_formatted_code = """\
+def foo_function(arg1, arg2,
+					arg3):
+	return [
+			'hello',
+			'world',
+	]
+"""
+    style_contents = u"""\
+[style]
+based_on_style = chromium
+USE_TABS = true
+COLUMN_LIMIT=32
+INDENT_WIDTH=4
+CONTINUATION_INDENT_WIDTH=8
+CONTINUATION_ALIGNMENT_TYPE = more
+"""
+    with utils.TempFileContents(self.test_tmpdir, style_contents) as stylepath:
+      self.assertYapfReformats(
+          unformatted_code,
+          expected_formatted_code,
+          extra_options=['--style={0}'.format(stylepath)])
+
   def testStyleOutputRoundTrip(self):
     unformatted_code = textwrap.dedent("""\
         def foo_function():


### PR DESCRIPTION
The following alignment modes are implemented:

- `SPACE`: vertically align with spaces. current (0.20.2) and default behavior.
- `FIXED`: just use fixed number of tabs (`CONTINUATION_INDENT_WIDTH` / `INDENT_WIDTH`).
- `LESS`: Slightly left if cannot vertically align continuation lines with tabs.
- `MORE`: Slightly right if cannot vertically align continuation lines with tabs.

Here is how different mode look like:

<img width="276" alt="continuation_alignment_type" src="https://user-images.githubusercontent.com/71190/36739344-a20388de-1c1a-11e8-8d5a-2ab295c1ab58.png">

with configuration:

```YAML
[style]
based_on_style = chromium
USE_TABS = true
COLUMN_LIMIT=32
INDENT_WIDTH=4
CONTINUATION_INDENT_WIDTH=8
# CONTINUATION_ALIGNMENT_TYPE =
```

Test cases are added. But the function `_TabModeContAlignPadding()` I added to `format_token.py` for generating alignment padding string still marked as *miss* in coverage report. Tried to fix but no clue so far.