### PR TITLE
use ignore patterns from .yapfignore in CWD

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,10 @@
 # All notable changes to this project will be documented in this file.
 # This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.26.0] UNRELEASED
+### Added
+- Support additional file exclude patterns in .yapfignore file.
+
 ## [0.25.0] UNRELEASED
 ### Added
 - Added `INDENT_BLANK_LINES` knob to select whether the blank lines are empty

--- a/README.rst
+++ b/README.rst
@@ -136,6 +136,14 @@ If ``--diff`` is supplied, YAPF returns zero when no changes were necessary, non
 otherwise (including program error). You can use this in a CI workflow to test that code
 has been YAPF-formatted.
 
+---------------------------------------------
+Excluding files from formatting (.yapfignore)
+---------------------------------------------
+
+In addition to exlude patterns provided on commandline, YAPF looks for additional 
+patterns specified in a file named ``.yapfignore`` located in the working directory from 
+which YAPF is invoked.
+
 
 Formatting style
 ================

--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -188,8 +188,13 @@ def main(argv):
     file_resources.WriteReformattedCode('<stdout>', reformatted_source)
     return 0
 
-  files = file_resources.GetCommandLineFiles(args.files, args.recursive,
-                                             args.exclude)
+  # Get additional exclude patterns from ignorefile
+  exclude_patterns_from_ignore_file = file_resources.GetExcludePatternsForDir(
+      os.getcwd())
+
+  files = file_resources.GetCommandLineFiles(
+      args.files, args.recursive,
+      (args.exclude or []) + exclude_patterns_from_ignore_file)
   if not files:
     raise errors.YapfError('Input filenames did not match any python files')
 

--- a/yapf/yapflib/file_resources.py
+++ b/yapf/yapflib/file_resources.py
@@ -32,6 +32,36 @@ LF = '\n'
 CRLF = '\r\n'
 
 
+def _GetExcludePatternsFromFile(filename):
+  ignore_patterns = []
+  # See if we have a .yapfignore file.
+  if os.path.isfile(filename) and os.access(filename, os.R_OK):
+    for line in open(filename, 'r').readlines():
+      if line.strip() and not line.startswith('#'):
+        ignore_patterns.append(line.strip())
+
+    if any(e.startswith('./') for e in ignore_patterns):
+      raise errors.YapfError('path in .yapfignore should not start with ./')
+
+  return ignore_patterns
+
+
+def GetExcludePatternsForDir(dirname):
+  """Return patterns of files to exclude from ignorefile in a given directory.
+
+   Looks for .yapfignore in the directory dirname.
+
+   Arguments:
+     dirname: (unicode) The name of the directory.
+
+   Returns:
+     A List of file patterns to exclude if ignore file is found
+     , otherwhise empty List.
+   """
+  ignore_file = os.path.join(dirname, '.yapfignore')
+  return _GetExcludePatternsFromFile(ignore_file)
+
+
 def GetDefaultStyleForDir(dirname):
   """Return default style name for a given directory.
 

--- a/yapftests/file_resources_test.py
+++ b/yapftests/file_resources_test.py
@@ -36,6 +36,30 @@ def _restore_working_dir():
     os.chdir(curdir)
 
 
+class GetExcludePatternsForDir(unittest.TestCase):
+
+  def setUp(self):
+    self.test_tmpdir = tempfile.mkdtemp()
+
+  def tearDown(self):
+    shutil.rmtree(self.test_tmpdir)
+
+  def _make_test_dir(self, name):
+    fullpath = os.path.normpath(os.path.join(self.test_tmpdir, name))
+    os.makedirs(fullpath)
+    return fullpath
+
+  def test_get_exclude_file_patterns(self):
+    local_ignore_file = os.path.join(self.test_tmpdir, '.yapfignore')
+    ignore_patterns = ['temp/**/*.py', 'temp2/*.py']
+    with open(local_ignore_file, 'w') as f:
+      f.writelines('\n'.join(ignore_patterns))
+
+    self.assertEqual(
+        sorted(file_resources.GetExcludePatternsForDir(self.test_tmpdir)),
+        sorted(ignore_patterns))
+
+
 class GetDefaultStyleForDirTest(unittest.TestCase):
 
   def setUp(self):


### PR DESCRIPTION
In addition to exclude pattern `--exclude` provided on cmdline, also look for patterns in `.yapfignore` in CWD when yapf is run

fixes #357 