### PR TITLE
Bug: Does not exclude hidden folders in a relative context

### DIFF
--- a/yapf/yapflib/file_resources.py
+++ b/yapf/yapflib/file_resources.py
@@ -148,7 +148,10 @@ def _FindPythonFiles(filenames, recursive, exclude):
 
 def IsIgnored(path, exclude):
   """Return True if filename matches any patterns in exclude."""
-  return any(fnmatch.fnmatch(path.lstrip('./'), e.rstrip('/')) for e in exclude)
+  path = path.lstrip("/")
+  while path.startswith("./"):
+    path = path[2:]
+  return any(fnmatch.fnmatch(path, e.rstrip('/')) for e in exclude)
 
 
 def IsPythonFile(filename):

--- a/yapftests/file_resources_test.py
+++ b/yapftests/file_resources_test.py
@@ -35,6 +35,7 @@ def _restore_working_dir():
   finally:
     os.chdir(curdir)
 
+
 class GetDefaultStyleForDirTest(unittest.TestCase):
 
   def setUp(self):
@@ -159,12 +160,10 @@ class GetCommandLineFilesTest(unittest.TestCase):
     _touch_files(files)
 
     actual = file_resources.GetCommandLineFiles(
-                [self.test_tmpdir], recursive=True, exclude=['*.test1*'])
+        [self.test_tmpdir], recursive=True, exclude=['*.test1*'])
 
     self.assertEqual(
-        sorted(
-            actual
-        ),
+        sorted(actual),
         sorted([
             os.path.join(tdir2, 'testfile2.py'),
             os.path.join(tdir3, 'testfile3.py'),
@@ -184,9 +183,9 @@ class GetCommandLineFilesTest(unittest.TestCase):
     tdir2 = self._make_test_dir('test_2')
     tdir3 = self._make_test_dir('test.3')
     files = [
-      os.path.join(tdir1, 'testfile1.py'),
-      os.path.join(tdir2, 'testfile2.py'),
-      os.path.join(tdir3, 'testfile3.py'),
+        os.path.join(tdir1, 'testfile1.py'),
+        os.path.join(tdir2, 'testfile2.py'),
+        os.path.join(tdir3, 'testfile3.py'),
     ]
     _touch_files(files)
 
@@ -196,19 +195,20 @@ class GetCommandLineFilesTest(unittest.TestCase):
 
       os.chdir(self.test_tmpdir)
       actual = file_resources.GetCommandLineFiles(
-        [os.path.relpath(self.test_tmpdir)],
-        recursive=True, exclude=['*.test1*'])
+          [os.path.relpath(self.test_tmpdir)],
+          recursive=True,
+          exclude=['*.test1*'])
 
       self.assertEqual(
-        sorted(
-          actual
-        ),
-        sorted([
-          os.path.join(os.path.relpath(self.test_tmpdir),
-                       os.path.basename(tdir2), 'testfile2.py'),
-          os.path.join(os.path.relpath(self.test_tmpdir),
-                       os.path.basename(tdir3), 'testfile3.py'),
-        ]))
+          sorted(actual),
+          sorted([
+              os.path.join(
+                  os.path.relpath(self.test_tmpdir), os.path.basename(tdir2),
+                  'testfile2.py'),
+              os.path.join(
+                  os.path.relpath(self.test_tmpdir), os.path.basename(tdir3),
+                  'testfile3.py'),
+          ]))
 
   def test_find_with_excluded_dirs(self):
     tdir1 = self._make_test_dir('test1')


### PR DESCRIPTION
This bug arises when the root directory is specified as a relative path, and when you are trying to exclude an immediate child directory (or file) which starts with a period. The exclusion pattern is fine, but the file path(s) it is being compared against are each over-stripped so that the period is no longer present.

In this example, the exclusion filter has failed to prevent changing `dependency.py`

    user@host:/var/project# file ./.serverless
    ./.serverless: directory

    user@host:/var/project# yapf -vv --recursive --exclude '*/.serverless/*' -i .
    Reformatting ./.serverless/requirements/dependency.py
    [--snip--]

For anyone discovering this PR who has the same problem, a workaround is to use an absolute path to the current directory instead:

    user@host:/var/project# yapf -vv --recursive --exclude '*/.serverless/*' -i `pwd`
    Reformatting /var/project/acme/exceptions.py
    [--snip--]