### PR TITLE
Added an option to split on all args even if not comma terminated.

### DIFF
--- a/yapf/yapflib/format_decision_state.py
+++ b/yapf/yapflib/format_decision_state.py
@@ -375,6 +375,13 @@ class FormatDecisionState(object):
         if previous.value in '(,':
           if opening.matching_bracket.previous_token.value == ',':
             return True
+    if style.Get('SPLIT_ARGUMENTS'):
+      # Split before arguments in a function call or definition if the
+      # arguments are terminated by a comma.
+      opening = _GetOpeningBracket(current)
+      if opening and opening.previous_token and opening.previous_token.is_name:
+        if previous.value in '(,' and opening.matching_bracket:
+          return True
 
     if ((current.is_name or current.value in {'*', '**'}) and
         previous.value == ','):

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -175,6 +175,8 @@ _STYLE_HELP = dict(
     SPLIT_ARGUMENTS_WHEN_COMMA_TERMINATED=textwrap.dedent("""\
       Split before arguments if the argument list is terminated by a
       comma."""),
+    SPLIT_ARGUMENTS=textwrap.dedent("""\
+      Split before arguments"""),
     SPLIT_BEFORE_BITWISE_OPERATOR=textwrap.dedent("""\
       Set to True to prefer splitting before '&', '|' or '^' rather than
       after."""),
@@ -282,6 +284,7 @@ def CreatePEP8Style():
       SPACES_AROUND_DEFAULT_OR_NAMED_ASSIGN=False,
       SPACES_BEFORE_COMMENT=2,
       SPLIT_ARGUMENTS_WHEN_COMMA_TERMINATED=False,
+      SPLIT_ARGUMENTS=False,
       SPLIT_BEFORE_BITWISE_OPERATOR=True,
       SPLIT_BEFORE_CLOSING_BRACKET=True,
       SPLIT_BEFORE_DICT_SET_GENERATOR=True,
@@ -429,6 +432,7 @@ _STYLE_OPTION_VALUE_CONVERTER = dict(
     SPACES_AROUND_DEFAULT_OR_NAMED_ASSIGN=_BoolConverter,
     SPACES_BEFORE_COMMENT=int,
     SPLIT_ARGUMENTS_WHEN_COMMA_TERMINATED=_BoolConverter,
+    SPLIT_ARGUMENTS=_BoolConverter,
     SPLIT_BEFORE_BITWISE_OPERATOR=_BoolConverter,
     SPLIT_BEFORE_CLOSING_BRACKET=_BoolConverter,
     SPLIT_BEFORE_DICT_SET_GENERATOR=_BoolConverter,


### PR DESCRIPTION
I noticed that there was an option to split args to individual lines, but only when comma terminated. I wanted an option to do this on all args, so I implemented something that seemed to work.

What else is needed to get this change accepted? I reviewed the contributing guidelines and seem to be in compliance with all of them, but there were not many.