### PR TITLE
initial version, include missing files in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include HACKING.rst LICENSE AUTHORS CHANGELOG CONTRIBUTING.rst CONTRIBUTORS
+include .coveragerc .editorconfig .flake8 plugins/README.rst
+include plugins/vim/autoload/yapf.vim plugins/vim/plugin/yapf.vim pylintrc
+include .style.yapf tox.ini .travis.yml .vimrc


### PR DESCRIPTION
LICENSE file is missing from tarball, which is recommended to include for the Fedora package.

I've also added more missing files.