### PR TITLE
py3compat: remove any BOM

### DIFF
--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -176,6 +176,7 @@ def main(argv):
       style_config = file_resources.GetDefaultStyleForDir(os.getcwd())
 
     source = [line.rstrip() for line in original_source]
+    source[0] = py3compat.removeBOM(source[0])
     reformatted_source, _ = yapf_api.FormatCode(
         py3compat.unicode('\n'.join(source) + '\n'),
         filename='<stdin>',

--- a/yapf/yapflib/py3compat.py
+++ b/yapf/yapflib/py3compat.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Utilities for Python2 / Python3 compatibility."""
 
+import codecs
 import io
 import os
 import sys
@@ -116,3 +117,13 @@ class ConfigParser(configparser.ConfigParser):
 
     def read_file(self, fp, source=None):
       self.readfp(fp, filename=source)
+
+
+def removeBOM(source):
+  """Remove any Byte-order-Mark bytes from the beginning of a file."""
+  bom = codecs.BOM_UTF8
+  if PY3:
+    bom = bom.decode('utf-8')
+  if source.startswith(bom):
+    return source[len(bom):]
+  return source

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -411,7 +411,8 @@ class CommandLineTest(unittest.TestCase):
         stdin=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env=env)
-    reformatted_code, stderrdata = p.communicate(unformatted.encode('utf-8'))
+    reformatted_code, stderrdata = p.communicate(
+        unformatted.encode('utf-8-sig'))
     self.assertEqual(stderrdata, b'')
     self.assertMultiLineEqual(reformatted_code.decode('utf-8'), expected)
 


### PR DESCRIPTION
This is a redo of #384 as it got lost...

----

Currently yapf fails on files containing the infamous BOM. Those two commits are an attempt to test and fix that issue.

This was the easiest way I found to test it but it's kind of agressive. I'm keen on knowing a better way.

Cheers,