### PR TITLE
Adds an INDENT_BLANK_LINES option.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@
 - Added 'SPLIT_BEFORE_DOT' knob to support "builder style" calls. The "builder
   style" option didn't work as advertised. Lines would split after the dots,
   not before them regardless of the penalties.
+- Added `INDENT_BLANK_LINES` knob to select whether the blank lines are empty
+  or indented consistently with the current block.
 ### Fixed
 - Don't count inner function calls when marking arguments as named assignments.
 - Make sure that tuples and the like are formatted nicely if they all can't fit

--- a/README.rst
+++ b/README.rst
@@ -448,6 +448,9 @@ Knobs
 ``INDENT_WIDTH``
     The number of columns to use for indentation.
 
+``INDENT_BLANK_LINES``
+    Set to ``True`` to prefer indented blank lines rather than empty
+
 ``JOIN_MULTIPLE_LINES``
     Join short lines into one line. E.g., single line ``if`` statements.
 

--- a/yapf/yapflib/format_token.py
+++ b/yapf/yapflib/format_token.py
@@ -142,17 +142,11 @@ class FormatToken(object):
   @property
   def formatted_whitespace_prefix(self):
     if style.Get('INDENT_BLANK_LINES'):
-      without_newline = self.whitespace_prefix.lstrip('\n')
-      without_spaces = without_newline.lstrip(' ')
-      height = len(self.whitespace_prefix) - len(without_newline)
-      depth = len(without_newline) - len(without_spaces)
-      formatted_whitespace_prefix = ('\n' + ' ' * depth) * height
-      if not formatted_whitespace_prefix:
-        formatted_whitespace_prefix += ' ' * depth
-      formatted_whitespace_prefix += without_spaces
-      return formatted_whitespace_prefix
-    else:
-      return self.whitespace_prefix
+      without_newlines = self.whitespace_prefix.lstrip('\n')
+      height = len(self.whitespace_prefix) - len(without_newlines)
+      if height:
+        return ('\n' + without_newlines) * height
+    return self.whitespace_prefix
 
   def AddWhitespacePrefix(self, newlines_before, spaces=0, indent_level=0):
     """Register a token's whitespace prefix.

--- a/yapf/yapflib/format_token.py
+++ b/yapf/yapflib/format_token.py
@@ -139,6 +139,21 @@ class FormatToken(object):
     else:
       self.value = self.node.value
 
+  @property
+  def formatted_whitespace_prefix(self):
+    if style.Get('INDENT_BLANK_LINES'):
+      without_newline = self.whitespace_prefix.lstrip('\n')
+      without_spaces = without_newline.lstrip(' ')
+      height = len(self.whitespace_prefix) - len(without_newline)
+      depth = len(without_newline) - len(without_spaces)
+      formatted_whitespace_prefix = ('\n' + ' '*depth)*height
+      if not formatted_whitespace_prefix:
+        formatted_whitespace_prefix += ' '*depth
+      formatted_whitespace_prefix += without_spaces
+      return formatted_whitespace_prefix
+    else:
+      return self.whitespace_prefix
+
   def AddWhitespacePrefix(self, newlines_before, spaces=0, indent_level=0):
     """Register a token's whitespace prefix.
 

--- a/yapf/yapflib/format_token.py
+++ b/yapf/yapflib/format_token.py
@@ -146,9 +146,9 @@ class FormatToken(object):
       without_spaces = without_newline.lstrip(' ')
       height = len(self.whitespace_prefix) - len(without_newline)
       depth = len(without_newline) - len(without_spaces)
-      formatted_whitespace_prefix = ('\n' + ' '*depth)*height
+      formatted_whitespace_prefix = ('\n' + ' ' * depth) * height
       if not formatted_whitespace_prefix:
-        formatted_whitespace_prefix += ' '*depth
+        formatted_whitespace_prefix += ' ' * depth
       formatted_whitespace_prefix += without_spaces
       return formatted_whitespace_prefix
     else:

--- a/yapf/yapflib/reformatter.py
+++ b/yapf/yapflib/reformatter.py
@@ -254,7 +254,7 @@ def _FormatFinalLines(final_lines, verify):
     formatted_line = []
     for tok in line.tokens:
       if not tok.is_pseudo_paren:
-        formatted_line.append(tok.whitespace_prefix)
+        formatted_line.append(tok.formatted_whitespace_prefix)
         formatted_line.append(tok.value)
       else:
         if (not tok.next_token.whitespace_prefix.startswith('\n') and

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -154,6 +154,8 @@ _STYLE_HELP = dict(
         }"""),
     INDENT_WIDTH=textwrap.dedent("""\
       The number of columns to use for indentation."""),
+    INDENT_BLANK_LINES=textwrap.dedent("""\
+      Indent blank lines."""),
     JOIN_MULTIPLE_LINES=textwrap.dedent("""\
       Join short lines into one line. E.g., single line 'if' statements."""),
     NO_SPACES_AROUND_SELECTED_BINARY_OPERATORS=textwrap.dedent("""\
@@ -281,6 +283,7 @@ def CreatePEP8Style():
       I18N_FUNCTION_CALL='',
       INDENT_DICTIONARY_VALUE=False,
       INDENT_WIDTH=4,
+      INDENT_BLANK_LINES=False,
       JOIN_MULTIPLE_LINES=True,
       SPACE_BETWEEN_ENDING_COMMA_AND_CLOSING_BRACKET=True,
       SPACES_AROUND_POWER_OPERATOR=False,
@@ -430,6 +433,7 @@ _STYLE_OPTION_VALUE_CONVERTER = dict(
     I18N_FUNCTION_CALL=_StringListConverter,
     INDENT_DICTIONARY_VALUE=_BoolConverter,
     INDENT_WIDTH=int,
+    INDENT_BLANK_LINES=_BoolConverter,
     JOIN_MULTIPLE_LINES=_BoolConverter,
     NO_SPACES_AROUND_SELECTED_BINARY_OPERATORS=_StringSetConverter,
     SPACE_BETWEEN_ENDING_COMMA_AND_CLOSING_BRACKET=_BoolConverter,

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -133,6 +133,40 @@ class BasicReformatterTest(yapf_test_helper.YAPFTest):
     uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
     self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
 
+  def testIndentBlankLines(self):
+    try:
+      style.SetGlobalStyle(
+          style.CreateStyleFromConfig(
+              '{based_on_style: chromium, indent_blank_lines: true}'))
+      unformatted_code = textwrap.dedent("""\
+          class foo(object):
+
+            def foobar(self):
+
+              pass
+
+            def barfoo(self, x, y):  # bar
+
+              if x:
+
+                return y
+
+
+          def bar():
+
+            return 0
+          """)
+      expected_formatted_code = """class foo(object):\n  \n  def foobar(self):\n    \n    pass\n  \n  def barfoo(self, x, y):  # bar\n    \n    if x:\n      \n      return y\n\n\ndef bar():\n  \n  return 0\n"""
+      uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
+      self.assertCodeEqual(expected_formatted_code,
+                           reformatter.Reformat(uwlines))
+    finally:
+      style.SetGlobalStyle(style.CreateChromiumStyle())
+
+    unformatted_code, expected_formatted_code = expected_formatted_code, unformatted_code
+    uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
+    self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
+
   def testMultipleUgliness(self):
     unformatted_code = textwrap.dedent("""\
         x = {  'a':37,'b':42,


### PR DESCRIPTION
Adds an INDENT_BLANK_LINES option in order to allow indentation to continue on blank lines. Might be useful when trying to copy and paste pieces of code directly into a Python interpreter.