### PR TITLE
split_before_first_base_class option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@
 ### Added
 - `DISABLE_ENDING_COMMA_HEURISTIC` is a new knob to disable the heuristic which
   splits a list onto separate lines if the list is comma-terminated.
+- `SPLIT_BEFORE_FIRST_BASE_CLASS` is analagous to SPLIT_BEFORE_FIRST_ARGUMENT
+  but for class definitions.
 ### Fixed
 - There's no need to increase N_TOKENS. In fact, it causes other things which
   use lib2to3 to fail if called from YAPF.

--- a/README.rst
+++ b/README.rst
@@ -511,6 +511,10 @@ Knobs
     If an argument / parameter list is going to be split, then split before the
     first argument.
 
+``SPLIT_BEFORE_FIRST_BASE_CLASS`
+    If a list of base classes is going to be split, then split before the first
+    base class.
+
 ``SPLIT_BEFORE_LOGICAL_OPERATOR``
     Set to ``True`` to prefer splitting before ``and`` or ``or`` rather than
     after.

--- a/yapf/yapflib/format_decision_state.py
+++ b/yapf/yapflib/format_decision_state.py
@@ -197,17 +197,16 @@ class FormatDecisionState(object):
     if (style.Get('DEDENT_CLOSING_BRACKETS') or
         style.Get('SPLIT_BEFORE_FIRST_ARGUMENT') or
         style.Get('SPLIT_BEFORE_FIRST_BASE_CLASS')):
-  
+
       # Prevent splitting before the first argument in compound statements
       # with the exception of function declarations and classes if configured.
       # DEDENT_CLOSING_BRACKETS silently implies the SPLIT_BEFORE_FIRST_*
       # for *all* compound statements.
       if _IsCompoundStatement(self.line.first) and not (
           (style.Get('SPLIT_BEFORE_FIRST_ARGUMENT') and
-          _IsFunctionDef(self.line.first)) or
+           _IsFunctionDef(self.line.first)) or
           (style.Get('SPLIT_BEFORE_FIRST_BASE_CLASS') and
-          _IsClass(self.line.first)) or
-          style.Get('DEDENT_CLOSING_BRACKETS')):
+           _IsClass(self.line.first)) or style.Get('DEDENT_CLOSING_BRACKETS')):
         return False
 
       bracket = current if current.ClosesScope() else previous

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -201,6 +201,9 @@ _STYLE_HELP = dict(
     SPLIT_BEFORE_FIRST_ARGUMENT=textwrap.dedent("""\
       If an argument / parameter list is going to be split, then split before
       the first argument."""),
+    SPLIT_BEFORE_FIRST_BASE_CLASS=textwrap.dedent("""\
+      If a list of base classes is going to be split, then split before the
+      first base class."""),
     SPLIT_BEFORE_LOGICAL_OPERATOR=textwrap.dedent("""\
       Set to True to prefer splitting before 'and' or 'or' rather than
       after."""),
@@ -294,6 +297,7 @@ def CreatePEP8Style():
       SPLIT_BEFORE_DICT_SET_GENERATOR=True,
       SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN=False,
       SPLIT_BEFORE_FIRST_ARGUMENT=False,
+      SPLIT_BEFORE_FIRST_BASE_CLASS=False,
       SPLIT_BEFORE_LOGICAL_OPERATOR=True,
       SPLIT_BEFORE_NAMED_ASSIGNS=True,
       SPLIT_COMPLEX_COMPREHENSION=False,
@@ -443,6 +447,7 @@ _STYLE_OPTION_VALUE_CONVERTER = dict(
     SPLIT_BEFORE_DICT_SET_GENERATOR=_BoolConverter,
     SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN=_BoolConverter,
     SPLIT_BEFORE_FIRST_ARGUMENT=_BoolConverter,
+    SPLIT_BEFORE_FIRST_BASE_CLASS=_BoolConverter,
     SPLIT_BEFORE_LOGICAL_OPERATOR=_BoolConverter,
     SPLIT_BEFORE_NAMED_ASSIGNS=_BoolConverter,
     SPLIT_COMPLEX_COMPREHENSION=_BoolConverter,

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -2421,7 +2421,8 @@ s = 'foo \\
     try:
       style.SetGlobalStyle(
           style.CreateStyleFromConfig(
-              '{based_on_style: chromium, split_before_first_base_class: True}'))
+              '{based_on_style: chromium, split_before_first_base_class: True}')
+      )
       unformatted_code = textwrap.dedent("""\
           class _NumberOfSecondsFromElementsGetter(SomeBase, SomeOtherBase,
                                               SomeThirdBase):

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -2416,6 +2416,28 @@ s = 'foo \\
     finally:
       style.SetGlobalStyle(style.CreateChromiumStyle())
 
+  def testSplittingBeforeFirstBaseClassOnClassDefinition(self):
+    """Tests split_before_first_base_class on a function definition."""
+    try:
+      style.SetGlobalStyle(
+          style.CreateStyleFromConfig(
+              '{based_on_style: chromium, split_before_first_base_class: True}'))
+      unformatted_code = textwrap.dedent("""\
+          class _NumberOfSecondsFromElementsGetter(SomeBase, SomeOtherBase,
+                                              SomeThirdBase):
+            pass
+          """)
+      expected_formatted_code = textwrap.dedent("""\
+          class _NumberOfSecondsFromElementsGetter(
+              SomeBase, SomeOtherBase, SomeThirdBase):
+            pass
+          """)
+      uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
+      self.assertCodeEqual(expected_formatted_code,
+                           reformatter.Reformat(uwlines))
+    finally:
+      style.SetGlobalStyle(style.CreateChromiumStyle())
+
   def testCoalesceBracketsOnDict(self):
     """Tests coalesce_brackets on a dictionary."""
     try:

--- a/yapftests/reformatter_facebook_test.py
+++ b/yapftests/reformatter_facebook_test.py
@@ -23,6 +23,7 @@ from yapftests import yapf_test_helper
 
 
 class TestsForFacebookStyle(yapf_test_helper.YAPFTest):
+
   @classmethod
   def setUpClass(cls):
     style.SetGlobalStyle(style.CreateFacebookStyle())

--- a/yapftests/reformatter_facebook_test.py
+++ b/yapftests/reformatter_facebook_test.py
@@ -23,7 +23,6 @@ from yapftests import yapf_test_helper
 
 
 class TestsForFacebookStyle(yapf_test_helper.YAPFTest):
-
   @classmethod
   def setUpClass(cls):
     style.SetGlobalStyle(style.CreateFacebookStyle())


### PR DESCRIPTION
Similar to split_before_first_argument, but for class definitions.

I also added a note about DEDENT_CLOSING_BRACKETS, rather than trying to fix
the behaviour, because it may be relied on by people.

