### PR TITLE
Don't add space between '.' and print

### DIFF
--- a/yapf/yapflib/unwrapped_line.py
+++ b/yapf/yapflib/unwrapped_line.py
@@ -317,9 +317,12 @@ def _SpaceRequiredBetween(left, right):
   if lval == '@' and format_token.Subtype.DECORATOR in left.subtypes:
     # Decorators shouldn't be separated from the 'at' sign.
     return False
-  if left.is_keyword and rval == '.' or lval == '.' and right.is_keyword:
+  if left.is_keyword and rval == '.':
     # Add space between keywords and dots.
-    return lval != 'None'
+    return lval != 'None' and lval != 'print'
+  if lval == '.' and right.is_keyword:
+    # Add space between keywords and dots.
+    return rval != 'None' and rval != 'print'
   if lval == '.' or rval == '.':
     # Don't place spaces between dots.
     return False

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -59,6 +59,11 @@ class FormatCodeTest(unittest.TestCase):
         """)
     self._Check(unformatted_code, expected_formatted_code)
 
+  def testPrintAfterPeriod(self):
+    unformatted_code = textwrap.dedent("""a.print\n""")
+    expected_formatted_code = textwrap.dedent("""a.print\n""")
+    self._Check(unformatted_code, expected_formatted_code)
+
 
 class FormatFileTest(unittest.TestCase):
 


### PR DESCRIPTION
To be honest, not sure we should ever be adding a space here, as
we can end up with class members that are keywords.

Also, I suspect that the existing logic is wrong, and should also be
checking rval, even if we don't want to add print to the checks.