### PR TITLE
Catch KeyboardInterrupt when reading from stdin.

### DIFF
--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -174,6 +174,8 @@ def main(argv):
         original_source.append(py3compat.raw_input())
       except EOFError:
         break
+      except KeyboardInterrupt:
+        return 1
 
     if style_config is None and not args.no_local_style:
       style_config = file_resources.GetDefaultStyleForDir(os.getcwd())


### PR DESCRIPTION
Do not print traceback and directly exit with error code.

This is more consistent with other UNIX CLI tools.
