### PR TITLE
Allow custom default for GetDefaultStyleForDir()

### DIFF
--- a/yapf/yapflib/file_resources.py
+++ b/yapf/yapflib/file_resources.py
@@ -32,16 +32,18 @@ LF = '\n'
 CRLF = '\r\n'
 
 
-def GetDefaultStyleForDir(dirname):
+def GetDefaultStyleForDir(dirname, default_style=style.DEFAULT_STYLE):
   """Return default style name for a given directory.
 
   Looks for .style.yapf or setup.cfg in the parent directories.
 
   Arguments:
     dirname: (unicode) The name of the directory.
+    default_style: The style to return if nothing is found. Defaults to the
+                   global default style ('pep8') unless otherwise specified.
 
   Returns:
-    The filename if found, otherwise return the global default (pep8).
+    The filename if found, otherwise return the default style.
   """
   dirname = os.path.abspath(dirname)
   while True:
@@ -68,7 +70,7 @@ def GetDefaultStyleForDir(dirname):
   if os.path.exists(global_file):
     return global_file
 
-  return style.DEFAULT_STYLE
+  return default_style
 
 
 def GetCommandLineFiles(command_line_file_list, recursive, exclude):

--- a/yapftests/file_resources_test.py
+++ b/yapftests/file_resources_test.py
@@ -49,6 +49,12 @@ class GetDefaultStyleForDirTest(unittest.TestCase):
     style_name = file_resources.GetDefaultStyleForDir(test_file)
     self.assertEqual(style_name, 'pep8')
 
+  def test_no_local_style_custom_default(self):
+    test_file = os.path.join(self.test_tmpdir, 'file.py')
+    style_name = file_resources.GetDefaultStyleForDir(
+        test_file, default_style='custom-default')
+    self.assertEqual(style_name, 'custom-default')
+
   def test_with_local_style(self):
     # Create an empty .style.yapf file in test_tmpdir
     style_file = os.path.join(self.test_tmpdir, '.style.yapf')


### PR DESCRIPTION
Useful if you store a global (e.g. company-wide) fallback style in a file.