### PR TITLE
Updated `pre-commit` shell script

### DIFF
--- a/plugins/pre-commit.sh
+++ b/plugins/pre-commit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Git pre-commit hook to check staged Python files for formatting issues with
 # yapf.
@@ -21,15 +21,14 @@
 # is used.
 
 # Find all staged Python files, and exit early if there aren't any.
-PYTHON_FILES=(`git diff --name-only --cached --diff-filter=AM | \
-  grep --color=never '.py$'`)
-if [ ! "$PYTHON_FILES" ]; then
+PYTHON_FILES=$(git diff --name-only --cached --diff-filter=AM | grep --color=never '.py$')
+if [ -z "${PYTHON_FILES}" ]; then
   exit 0
 fi
 
 ########## PIP VERSION #############
 # Verify that yapf is installed; if not, warn and exit.
-if [ -z $(which yapf) ]; then
+if ! command -v yapf >/dev/null; then
   echo 'yapf not on path; can not format. Please install yapf:'
   echo '    pip install yapf'
   exit 2
@@ -37,7 +36,7 @@ fi
 ######### END PIP VERSION ##########
 
 ########## PIPENV VERSION ##########
-# if [ -z $(pipenv run which yapf) ]; then
+# if ! pipenv run yapf --version 2>/dev/null 2>&1; then
 #   echo 'yapf not on path; can not format. Please install yapf:'
 #   echo '    pipenv install yapf'
 #   exit 2
@@ -46,16 +45,12 @@ fi
 
 
 # Check for unstaged changes to files in the index.
-CHANGED_FILES=(`git diff --name-only ${PYTHON_FILES[@]}`)
-if [ "$CHANGED_FILES" ]; then
+CHANGED_FILES=$(git diff --name-only "${PYTHON_FILES[@]}")
+if [ -n "${CHANGED_FILES}" ]; then
   echo 'You have unstaged changes to some files in your commit; skipping '
   echo 'auto-format. Please stage, stash, or revert these changes. You may '
   echo 'find `git stash -k` helpful here.'
-  echo
-  echo 'Files with unstaged changes:'
-  for file in ${CHANGED_FILES[@]}; do
-    echo "  $file"
-  done
+  echo 'Files with unstaged changes:' "${CHANGED_FILES[@]}"
   exit 1
 fi
 
@@ -64,22 +59,18 @@ fi
 echo 'Formatting staged Python files . . .'
 
 ########## PIP VERSION #############
-yapf -i -r ${PYTHON_FILES[@]}
+yapf -i -r "${PYTHON_FILES[@]}"
 ######### END PIP VERSION ##########
 
 ########## PIPENV VERSION ##########
-# pipenv run yapf -i -r ${PYTHON_FILES[@]}
+# pipenv run yapf -i -r "${PYTHON_FILES[@]}"
 ###### END PIPENV VERSION ##########
 
 
-CHANGED_FILES=(`git diff --name-only ${PYTHON_FILES[@]}`)
-if [ "$CHANGED_FILES" ]; then
+CHANGED_FILES=$(git diff --name-only "${PYTHON_FILES[@]}")
+if [ -n "${CHANGED_FILES}" ]; then
   echo 'Reformatted staged files. Please review and stage the changes.'
-  echo
-  echo 'Files updated:'
-  for file in ${CHANGED_FILES[@]}; do
-    echo "  $file"
-  done
+  echo 'Files updated: ' "${CHANGED_FILES[@]}"
   exit 1
 else
   exit 0


### PR DESCRIPTION
- Updated shebang from `#!/bin/bash` to `#!/usr/bin/env bash` for [portability](https://en.wikipedia.org/wiki/Shebang_%28Unix%29#Portability) related issues.
- Double quote to prevent globbing and word splitting.
- Using `command -v` instead of `which`: The reason to select the former over the latter is that it avoids a dependency on something that is outside your shell.

Signed-off-by: Mpho Mphego <mpho112@gmail.com>