### PR TITLE
Added functionality to insert spaces around dicts, lists, and tuples.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,9 @@
 ### Added
 - `ALLOW_SPLIT_BEFORE_DEFAULT_OR_NAMED_ASSIGNS` allows us to split before
   default / named assignments.
+- Added `SPACES_AROUND_LIST_DELIMITERS`, `SPACES_AROUND_DICT_DELIMITERS`,
+  and `SPACES_AROUND_TUPLE_DELIMITERS` to add spaces after the opening-
+  and before the closing-delimiters for lists, dicts, and tuples.
 ### Changed
 - `SPACES_BEFORE_COMMENT` can now be assigned to a specific value (standard
   behavior) or a list of column values. When assigned to a list, trailing 

--- a/README.rst
+++ b/README.rst
@@ -485,6 +485,45 @@ Knobs
     Set to ``True`` to prefer spaces around the assignment operator for default
     or keyword arguments.
 
+``SPACES_AROUND_DICT_DELIMITERS``
+    Adds a space after the opening '{' and before the ending '}' dict delimiters.
+
+    .. code-block:: python
+
+        {1: 2}
+
+    will be formatted as:
+
+    .. code-block:: python
+
+        { 1: 2 }
+
+``SPACES_AROUND_LIST_DELIMITERS``
+    Adds a space after the opening '[' and before the ending ']' list delimiters.
+
+    .. code-block:: python
+
+        [1, 2]
+
+    will be formatted as:
+    
+    .. code-block:: python
+
+        [ 1, 2 ]
+
+``SPACES_AROUND_TUPLE_DELIMITERS``
+    Adds a space after the opening '(' and before the ending ')' tuple delimiters.
+
+    .. code-block:: python
+
+        (1, 2, 3)
+
+    will be formatted as:
+
+    .. code-block:: python
+
+        ( 1, 2, 3 )
+
 ``SPACES_BEFORE_COMMENT``
     The number of spaces required before a trailing comment.
     This can be a single value (representing the number of spaces
@@ -495,33 +534,41 @@ Knobs
     
     With spaces_before_comment=5:
     
-      1 + 1 # Adding values
+    .. code-block:: python
+
+        1 + 1 # Adding values
     
     will be formatted as:
     
-      1 + 1     # Adding values <-- 5 spaces between the end of the statement and comment
+    .. code-block:: python
+
+        1 + 1     # Adding values <-- 5 spaces between the end of the statement and comment
     
     With spaces_before_comment=15, 20:
     
-      1 + 1 # Adding values
-      two + two # More adding
-    
-      longer_statement # This is a longer statement
-      short # This is a shorter statement
-    
-      a_very_long_statement_that_extends_beyond_the_final_column # Comment
-      short # This is a shorter statement
-    
+    .. code-block:: python
+
+        1 + 1 # Adding values
+        two + two # More adding
+      
+        longer_statement # This is a longer statement
+        short # This is a shorter statement
+      
+        a_very_long_statement_that_extends_beyond_the_final_column # Comment
+        short # This is a shorter statement
+      
     will be formatted as:
     
-      1 + 1          # Adding values <-- end of line comments in block aligned to col 15
-      two + two      # More adding
-    
-      longer_statement    # This is a longer statement <-- end of line comments in block aligned to col 20
-      short               # This is a shorter statement
-    
-      a_very_long_statement_that_extends_beyond_the_final_column  # Comment <-- the end of line comments are aligned based on the line length
-      short                                                       # This is a shorter statement
+    .. code-block:: python
+
+        1 + 1          # Adding values <-- end of line comments in block aligned to col 15
+        two + two      # More adding
+      
+        longer_statement    # This is a longer statement <-- end of line comments in block aligned to col 20
+        short               # This is a shorter statement
+      
+        a_very_long_statement_that_extends_beyond_the_final_column  # Comment <-- the end of line comments are aligned based on the line length
+        short                                                       # This is a shorter statement
 
 ``SPACE_BETWEEN_ENDING_COMMA_AND_CLOSING_BRACKET``
     Insert a space between the ending comma and closing bracket of a list, etc.

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -31,6 +31,11 @@ def Get(setting_name):
   return _style[setting_name]
 
 
+def GetOrDefault(setting_name, default_value):
+  """Get a style setting or default value if the setting does not exist."""
+  return _style.get(setting_name, default_value)
+
+
 def Help():
   """Return dict mapping style names to help strings."""
   return _STYLE_HELP
@@ -178,6 +183,36 @@ _STYLE_HELP = dict(
       Use spaces around the power operator."""),
     SPACES_AROUND_DEFAULT_OR_NAMED_ASSIGN=textwrap.dedent("""\
       Use spaces around default or named assigns."""),
+    SPACES_AROUND_DICT_DELIMITERS=textwrap.dedent("""\
+      Adds a space after the opening '{' and before the ending '}' dict delimiters.
+      
+        {1: 2}
+
+      will be formatted as:
+
+        { 1: 2 }
+
+      """),
+    SPACES_AROUND_LIST_DELIMITERS=textwrap.dedent("""\
+      Adds a space after the opening '[' and before the ending ']' list delimiters.
+      
+        [1, 2]
+        
+      will be formatted as:
+      
+        [ 1, 2 ]
+        
+      """),
+    SPACES_AROUND_TUPLE_DELIMITERS=textwrap.dedent("""\
+      Adds a space after the opening '(' and before the ending ')' tuple delimiters.
+      
+        (1, 2, 3)
+        
+      will be formatted as:
+      
+        ( 1, 2, 3 )
+        
+      """),
     SPACES_BEFORE_COMMENT=textwrap.dedent("""\
       The number of spaces required before a trailing comment.
       This can be a single value (representing the number of spaces
@@ -340,6 +375,9 @@ def CreatePEP8Style():
       SPACE_BETWEEN_ENDING_COMMA_AND_CLOSING_BRACKET=True,
       SPACES_AROUND_POWER_OPERATOR=False,
       SPACES_AROUND_DEFAULT_OR_NAMED_ASSIGN=False,
+      SPACES_AROUND_DICT_DELIMITERS=False,
+      SPACES_AROUND_LIST_DELIMITERS=False,
+      SPACES_AROUND_TUPLE_DELIMITERS=False,
       SPACES_BEFORE_COMMENT=2,
       SPLIT_ARGUMENTS_WHEN_COMMA_TERMINATED=False,
       SPLIT_ALL_COMMA_SEPARATED_VALUES=False,
@@ -510,6 +548,9 @@ _STYLE_OPTION_VALUE_CONVERTER = dict(
     SPACE_BETWEEN_ENDING_COMMA_AND_CLOSING_BRACKET=_BoolConverter,
     SPACES_AROUND_POWER_OPERATOR=_BoolConverter,
     SPACES_AROUND_DEFAULT_OR_NAMED_ASSIGN=_BoolConverter,
+    SPACES_AROUND_DICT_DELIMITERS=_BoolConverter,
+    SPACES_AROUND_LIST_DELIMITERS=_BoolConverter,
+    SPACES_AROUND_TUPLE_DELIMITERS=_BoolConverter,
     SPACES_BEFORE_COMMENT=_IntOrIntListConverter,
     SPLIT_ARGUMENTS_WHEN_COMMA_TERMINATED=_BoolConverter,
     SPLIT_ALL_COMMA_SEPARATED_VALUES=_BoolConverter,

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -136,7 +136,8 @@ _STYLE_HELP = dict(
             transform=Transformation.AVERAGE(window=timedelta(seconds=60)),
             start_ts=now()-timedelta(days=3),
             end_ts=now(),
-        )        # <--- this bracket is dedented and on a separate line"""),
+        )        # <--- this bracket is dedented and on a separate line
+      """),
     DISABLE_ENDING_COMMA_HEURISTIC=textwrap.dedent("""\
       Disable the heuristic which places each list element on a separate line
       if the list is comma-terminated."""),
@@ -159,7 +160,8 @@ _STYLE_HELP = dict(
                 'value1',
             'key2': value1 +
                     value2,
-        }"""),
+        }
+      """),
     INDENT_WIDTH=textwrap.dedent("""\
       The number of columns to use for indentation."""),
     INDENT_BLANK_LINES=textwrap.dedent("""\
@@ -174,7 +176,6 @@ _STYLE_HELP = dict(
       will be formatted as follows when configured with "*,/":
 
         1 + 2*3 - 4/5
-
       """),
     SPACE_BETWEEN_ENDING_COMMA_AND_CLOSING_BRACKET=textwrap.dedent("""\
       Insert a space between the ending comma and closing bracket of a list,
@@ -191,7 +192,6 @@ _STYLE_HELP = dict(
       will be formatted as:
 
         { 1: 2 }
-
       """),
     SPACES_AROUND_LIST_DELIMITERS=textwrap.dedent("""\
       Adds a space after the opening '[' and before the ending ']' list delimiters.
@@ -201,7 +201,6 @@ _STYLE_HELP = dict(
       will be formatted as:
       
         [ 1, 2 ]
-        
       """),
     SPACES_AROUND_TUPLE_DELIMITERS=textwrap.dedent("""\
       Adds a space after the opening '(' and before the ending ')' tuple delimiters.
@@ -211,7 +210,6 @@ _STYLE_HELP = dict(
       will be formatted as:
       
         ( 1, 2, 3 )
-        
       """),
     SPACES_BEFORE_COMMENT=textwrap.dedent("""\
       The number of spaces required before a trailing comment.

--- a/yapf/yapflib/unwrapped_line.py
+++ b/yapf/yapflib/unwrapped_line.py
@@ -25,6 +25,7 @@ from yapf.yapflib import pytree_utils
 from yapf.yapflib import split_penalty
 from yapf.yapflib import style
 
+from lib2to3.fixer_util import syms as python_symbols
 
 class UnwrappedLine(object):
   """Represents a single unwrapped line in the output.
@@ -513,9 +514,9 @@ def _IsDictListTupleDelimiterTok(tok, is_opening):
   assert open_tok.next_token.node.parent
 
   return open_tok.next_token.node.parent.type in [
-      281,  # dictsetmaker
-      304,  # listmaker
-      329,  # testlist_gexp
+      python_symbols.dictsetmaker,
+      python_symbols.listmaker,
+      python_symbols.testlist_gexp,
   ]
 
 

--- a/yapf/yapflib/unwrapped_line.py
+++ b/yapf/yapflib/unwrapped_line.py
@@ -27,6 +27,7 @@ from yapf.yapflib import style
 
 from lib2to3.fixer_util import syms as python_symbols
 
+
 class UnwrappedLine(object):
   """Represents a single unwrapped line in the output.
 

--- a/yapf/yapflib/unwrapped_line.py
+++ b/yapf/yapflib/unwrapped_line.py
@@ -345,8 +345,7 @@ def _SpaceRequiredBetween(left, right, is_line_disabled):
       (lval == '{' and rval == '}')):
     # Empty objects shouldn't be separated by spaces.
     return False
-  if ((lval in pytree_utils.OPENING_BRACKETS or
-       rval in pytree_utils.CLOSING_BRACKETS) and not is_line_disabled):
+  if not is_line_disabled and (left.OpensScope() or right.ClosesScope()):
     if (style.GetOrDefault('SPACES_AROUND_DICT_DELIMITERS', False) and (
         (lval == '{' and _IsDictListTupleDelimiterTok(left, is_opening=True)) or
         (rval == '}' and

--- a/yapf/yapflib/unwrapped_line.py
+++ b/yapf/yapflib/unwrapped_line.py
@@ -69,7 +69,7 @@ class UnwrappedLine(object):
     prev_length = self.first.total_length
     for token in self._tokens[1:]:
       if (token.spaces_required_before == 0 and
-          _SpaceRequiredBetween(prev_token, token)):
+          _SpaceRequiredBetween(prev_token, token, self.disable)):
         token.spaces_required_before = 1
 
       tok_len = len(token.value) if not token.is_pseudo_paren else 0
@@ -227,7 +227,7 @@ def _IsUnaryOperator(tok):
   return format_token.Subtype.UNARY_OPERATOR in tok.subtypes
 
 
-def _SpaceRequiredBetween(left, right):
+def _SpaceRequiredBetween(left, right, is_line_disabled):
   """Return True if a space is required between the left and right token."""
   lval = left.value
   rval = right.value
@@ -343,6 +343,23 @@ def _SpaceRequiredBetween(left, right):
       (lval == '{' and rval == '}')):
     # Empty objects shouldn't be separated by spaces.
     return False
+  if ((lval in pytree_utils.OPENING_BRACKETS or
+       rval in pytree_utils.CLOSING_BRACKETS) and not is_line_disabled):
+    if (style.GetOrDefault('SPACES_AROUND_DICT_DELIMITERS', False) and (
+        (lval == '{' and _IsDictListTupleDelimiterTok(left, is_opening=True)) or
+        (rval == '}' and
+         _IsDictListTupleDelimiterTok(right, is_opening=False)))):
+      return True
+    if (style.GetOrDefault('SPACES_AROUND_LIST_DELIMITERS', False) and (
+        (lval == '[' and _IsDictListTupleDelimiterTok(left, is_opening=True)) or
+        (rval == ']' and
+         _IsDictListTupleDelimiterTok(right, is_opening=False)))):
+      return True
+    if (style.GetOrDefault('SPACES_AROUND_TUPLE_DELIMITERS', False) and (
+        (lval == '(' and _IsDictListTupleDelimiterTok(left, is_opening=True)) or
+        (rval == ')' and
+         _IsDictListTupleDelimiterTok(right, is_opening=False)))):
+      return True
   if (lval in pytree_utils.OPENING_BRACKETS and
       rval in pytree_utils.OPENING_BRACKETS):
     # Nested objects' opening brackets shouldn't be separated.
@@ -473,6 +490,33 @@ def IsSurroundedByBrackets(tok):
 
     previous_token = previous_token.previous_token
   return None
+
+
+def _IsDictListTupleDelimiterTok(tok, is_opening):
+  assert tok
+
+  if tok.matching_bracket is None:
+    return False
+
+  if is_opening:
+    open_tok = tok
+    close_tok = tok.matching_bracket
+  else:
+    open_tok = tok.matching_bracket
+    close_tok = tok
+
+  # There must be something in between the tokens
+  if open_tok.next_token == close_tok:
+    return False
+
+  assert open_tok.next_token.node
+  assert open_tok.next_token.node.parent
+
+  return open_tok.next_token.node.parent.type in [
+      281,  # dictsetmaker
+      304,  # listmaker
+      329,  # testlist_gexp
+  ]
 
 
 _LOGICAL_OPERATORS = frozenset({'and', 'or'})

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -1717,5 +1717,188 @@ class HorizontallyAlignedTrailingCommentsTest(unittest.TestCase):
     self._Check(unformatted_code, expected_formatted_code)
 
 
+class _SpacesAroundDictListTupleTestImpl(unittest.TestCase):
+
+  @staticmethod
+  def _OwnStyle():
+    my_style = style.CreatePEP8Style()
+    my_style['DISABLE_ENDING_COMMA_HEURISTIC'] = True
+    my_style['SPLIT_ALL_COMMA_SEPARATED_VALUES'] = False
+    my_style['SPLIT_ARGUMENTS_WHEN_COMMA_TERMINATED'] = False
+    return my_style
+
+  def _Check(self, unformatted_code, expected_formatted_code):
+    formatted_code, _ = yapf_api.FormatCode(
+        unformatted_code, style_config=style.SetGlobalStyle(self._OwnStyle()))
+    self.assertEqual(expected_formatted_code, formatted_code)
+
+  def setUp(self):
+    self.maxDiff = None
+
+
+class SpacesAroundDictTest(_SpacesAroundDictListTupleTestImpl):
+
+  @classmethod
+  def _OwnStyle(cls):
+    style = super(SpacesAroundDictTest, cls)._OwnStyle()
+    style['SPACES_AROUND_DICT_DELIMITERS'] = True
+
+    return style
+
+  def testStandard(self):
+    unformatted_code = textwrap.dedent("""\
+      {1 : 2}
+      {k:v for k, v in other.items()}
+      {k for k in [1, 2, 3]}
+
+      # The following statements should not change
+      {}
+      {1 : 2} # yapf: disable
+
+      # yapf: disable
+      {1 : 2}
+      # yapf: enable
+
+      # Dict settings should not impact lists or tuples
+      [1, 2]
+      (3, 4)
+      """)
+    expected_formatted_code = textwrap.dedent("""\
+      { 1: 2 }
+      { k: v for k, v in other.items() }
+      { k for k in [1, 2, 3] }
+      
+      # The following statements should not change
+      {}
+      {1 : 2} # yapf: disable
+
+      # yapf: disable
+      {1 : 2}
+      # yapf: enable
+      
+      # Dict settings should not impact lists or tuples
+      [1, 2]
+      (3, 4)
+      """)
+
+    self._Check(unformatted_code, expected_formatted_code)
+
+
+class SpacesAroundListTest(_SpacesAroundDictListTupleTestImpl):
+
+  @classmethod
+  def _OwnStyle(cls):
+    style = super(SpacesAroundListTest, cls)._OwnStyle()
+    style['SPACES_AROUND_LIST_DELIMITERS'] = True
+
+    return style
+
+  def testStandard(self):
+    unformatted_code = textwrap.dedent("""\
+      [a,b,c]
+      [4,5,]
+      [6, [7, 8], 9]
+      [v for v in [1,2,3] if v & 1]
+
+      # The following statements should not change
+      index[0]
+      index[a, b]
+      []
+      [v for v in [1,2,3] if v & 1] # yapf: disable
+
+      # yapf: disable
+      [a,b,c]
+      [4,5,]
+      # yapf: enable
+
+      # List settings should not impact dicts or tuples
+      {a: b}
+      (1, 2)
+      """)
+    expected_formatted_code = textwrap.dedent("""\
+      [ a, b, c ]
+      [ 4, 5, ]
+      [ 6, [ 7, 8 ], 9 ]
+      [ v for v in [ 1, 2, 3 ] if v & 1 ]
+
+      # The following statements should not change
+      index[0]
+      index[a, b]
+      []
+      [v for v in [1,2,3] if v & 1] # yapf: disable
+      
+      # yapf: disable
+      [a,b,c]
+      [4,5,]
+      # yapf: enable
+      
+      # List settings should not impact dicts or tuples
+      {a: b}
+      (1, 2)
+      """)
+
+    self._Check(unformatted_code, expected_formatted_code)
+
+
+class SpacesAroundTupleTest(_SpacesAroundDictListTupleTestImpl):
+
+  @classmethod
+  def _OwnStyle(cls):
+    style = super(SpacesAroundTupleTest, cls)._OwnStyle()
+    style['SPACES_AROUND_TUPLE_DELIMITERS'] = True
+
+    return style
+
+  def testStandard(self):
+    unformatted_code = textwrap.dedent("""\
+      (0, 1)
+      (2, 3)
+      (4, 5, 6,)
+      func((7, 8), 9)
+
+      # The following statements should not change
+      func(1, 2)
+      (this_func or that_func)(3, 4)
+      if (True and False): pass
+      ()
+
+      (0, 1) # yapf: disable
+
+      # yapf: disable
+      (0, 1)
+      (2, 3)
+      # yapf: enable
+
+      # Tuple settings should not impact dicts or lists
+      {a: b}
+      [3, 4]
+      """)
+    expected_formatted_code = textwrap.dedent("""\
+      ( 0, 1 )
+      ( 2, 3 )
+      ( 4, 5, 6, )
+      func(( 7, 8 ), 9)
+
+      # The following statements should not change
+      func(1, 2)
+      (this_func or that_func)(3, 4)
+      if (True and False): pass
+      ()
+      
+      (0, 1) # yapf: disable
+
+      # yapf: disable
+      (0, 1)
+      (2, 3)
+      # yapf: enable
+      
+      # Tuple settings should not impact dicts or lists
+      {a: b}
+      [3, 4]
+      """)
+
+    self._Check(unformatted_code, expected_formatted_code)
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Implemented part 2 of https://github.com/google/yapf/issues/654.

This change will insert spaces after opening- and before closing-tokens for dicts, lists, and tuples. There are 3 settings to control behavior for all of those types independently. The behavior will remain the same as it was before the change (no added spaces) if the settings are not provided.