### PR TITLE
improve option parsing of `CONTINUATION_ALIGN_STYLE`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,8 @@
   the list that is greater than the maximum line length in the block.
 - Don't modify the vertical spacing of a line that has a comment "pylint:
   disable=line-too-long". The line is expected to be too long.
+- improved `CONTINUATION_ALIGN_STYLE` to accept quoted or underline-separated
+  option value for passing option with command line arguments.
 ### Fixed
 - When retrieving the opening bracket make sure that it's actually an opening
   bracket.

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -437,7 +437,7 @@ def _ContinuationAlignStyleStringConverter(s):
   """Option value converter for a continuation align style string."""
   accepted_styles = ('SPACE', 'FIXED', 'VALIGN-RIGHT')
   if s:
-    r = s.upper()
+    r = s.strip('"\'').replace('_', '-').upper()
     if r not in accepted_styles:
       raise ValueError('unknown continuation align style: %r' % (s,))
   else:

--- a/yapftests/style_test.py
+++ b/yapftests/style_test.py
@@ -27,14 +27,25 @@ from yapftests import utils
 class UtilsTest(unittest.TestCase):
 
   def testContinuationAlignStyleStringConverter(self):
-    self.assertEqual(style._ContinuationAlignStyleStringConverter(''), 'SPACE')
-    self.assertEqual(
-        style._ContinuationAlignStyleStringConverter('space'), 'SPACE')
-    self.assertEqual(
-        style._ContinuationAlignStyleStringConverter('fixed'), 'FIXED')
-    self.assertEqual(
-        style._ContinuationAlignStyleStringConverter('valign-right'),
-        'VALIGN-RIGHT')
+    for cont_align_space in ('', 'space', '"space"', '\'space\''):
+      self.assertEqual(
+          style._ContinuationAlignStyleStringConverter(cont_align_space),
+          'SPACE')
+    for cont_align_fixed in ('fixed', '"fixed"', '\'fixed\''):
+      self.assertEqual(
+          style._ContinuationAlignStyleStringConverter(cont_align_fixed),
+          'FIXED')
+    for cont_align_valignright in (
+        'valign-right',
+        '"valign-right"',
+        '\'valign-right\'',
+        'valign_right',
+        '"valign_right"',
+        '\'valign_right\'',
+    ):
+      self.assertEqual(
+          style._ContinuationAlignStyleStringConverter(cont_align_valignright),
+          'VALIGN-RIGHT')
     with self.assertRaises(ValueError) as ctx:
       style._ContinuationAlignStyleStringConverter('blahblah')
     self.assertIn("unknown continuation align style: 'blahblah'",


### PR DESCRIPTION
Accepts quoted or underline-separated option values for continuation alignment style.

This PR should fixes #616 and #646. `VALIGN-RIGHT` will be able to set with:

`yapf --style='{use_tabs: true, continuation_align_style: "valign-right"}'` or `yapf --style='{use_tabs: true, continuation_align_style: valign_right}'`