### PR TITLE
FIX: avoid split_before_first_argument if set to False

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,9 @@
 - Parse integer lists correctly, removing quotes if the list is within a
   string.
 - Adjust the penalties of bitwise operands for '&' and '^', similar to '|'.
+- Avoid splitting after opening parens if SPLIT_BEFORE_FIRST_ARGUMENT is set
+  to False.
+- Adjust default SPLIT_PENALTY_AFTER_OPENING_BRACKET.
 
 ## [0.26.0] 2019-02-08
 ### Added
@@ -20,7 +23,7 @@
   if they have higher precedence than other operators in the same expression.
 ### Changed
 - `SPACES_BEFORE_COMMENT` can now be assigned to a specific value (standard
-  behavior) or a list of column values. When assigned to a list, trailing 
+  behavior) or a list of column values. When assigned to a list, trailing
   comments will be horizontally aligned to the first column value within
   the list that is greater than the maximum line length in the block.
 - Don't modify the vertical spacing of a line that has a comment "pylint:

--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -195,9 +195,9 @@ def main(argv):
   exclude_patterns_from_ignore_file = file_resources.GetExcludePatternsForDir(
       os.getcwd())
 
-  files = file_resources.GetCommandLineFiles(
-      args.files, args.recursive,
-      (args.exclude or []) + exclude_patterns_from_ignore_file)
+  files = file_resources.GetCommandLineFiles(args.files, args.recursive,
+                                             (args.exclude or []) +
+                                             exclude_patterns_from_ignore_file)
   if not files:
     raise errors.YapfError('Input filenames did not match any python files')
 

--- a/yapf/yapflib/reformatter.py
+++ b/yapf/yapflib/reformatter.py
@@ -660,8 +660,9 @@ def _CalculateNumberOfNewlines(first_token, indent_depth, prev_uwline,
             prev_last_token.AdjustNewlinesBefore(
                 1 + style.Get('BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION'))
           if first_token.newlines is not None:
-            pytree_utils.SetNodeAnnotation(
-                first_token.node, pytree_utils.Annotation.NEWLINES, None)
+            pytree_utils.SetNodeAnnotation(first_token.node,
+                                           pytree_utils.Annotation.NEWLINES,
+                                           None)
           return NO_BLANK_LINES
     elif _IsClassOrDef(prev_uwline):
       if not style.Get('BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF'):

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -204,7 +204,7 @@ _STYLE_HELP = dict(
       alignment column values; trailing comments within a block will
       be aligned to the first column value that is greater than the maximum
       line length within the block). For example:
-      
+
       With spaces_before_comment=5:
 
         1 + 1 # Adding values
@@ -379,7 +379,7 @@ def CreatePEP8Style():
       SPLIT_BEFORE_LOGICAL_OPERATOR=True,
       SPLIT_BEFORE_NAMED_ASSIGNS=True,
       SPLIT_COMPLEX_COMPREHENSION=False,
-      SPLIT_PENALTY_AFTER_OPENING_BRACKET=30,
+      SPLIT_PENALTY_AFTER_OPENING_BRACKET=300,
       SPLIT_PENALTY_AFTER_UNARY_OPERATOR=10000,
       SPLIT_PENALTY_ARITHMETIC_OPERATOR=300,
       SPLIT_PENALTY_BEFORE_IF_EXPR=0,

--- a/yapftests/reformatter_buganizer_test.py
+++ b/yapftests/reformatter_buganizer_test.py
@@ -1546,7 +1546,7 @@ class _():
     try:
       style.SetGlobalStyle(
           style.CreateStyleFromConfig(
-              '{based_on_style: pep8, split_penalty_import_names: 35}'))
+              '{based_on_style: pep8, split_penalty_import_names: 350}'))
       unformatted_code = textwrap.dedent("""\
           from a_very_long_or_indented_module_name_yada_yada import (long_argument_1,
                                                                      long_argument_2)
@@ -2193,8 +2193,8 @@ dddddddddddddddddd().eeeeeeeeeeeeeeeeeeeee().fffffffffffffffff().ggggggggggggggg
             })
         """)
     expected_formatted_code = textwrap.dedent("""\
-        shelf_renderer.expand_text = text.translate_to_unicode(
-            expand_text % {'creator': creator})
+        shelf_renderer.expand_text = text.translate_to_unicode(expand_text %
+                                                               {'creator': creator})
         """)
     uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
     self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))

--- a/yapftests/reformatter_pep8_test.py
+++ b/yapftests/reformatter_pep8_test.py
@@ -190,8 +190,10 @@ class TestsForPEP8Style(yapf_test_helper.YAPFTest):
         if (aaaaaaaaaaaaaa + bbbbbbbbbbbbbbbb == ccccccccccccccccc and xxxxxxxxxxxxx
                 or yyyyyyyyyyyyyyyyy):
             pass
-        elif (xxxxxxxxxxxxxxx(
-                aaaaaaaaaaa, bbbbbbbbbbbbbb, cccccccccccc, dddddddddd=None)):
+        elif (xxxxxxxxxxxxxxx(aaaaaaaaaaa,
+                              bbbbbbbbbbbbbb,
+                              cccccccccccc,
+                              dddddddddd=None)):
             pass
 
 

--- a/yapftests/reformatter_style_config_test.py
+++ b/yapftests/reformatter_style_config_test.py
@@ -121,6 +121,78 @@ class TestsForStyleConfig(yapf_test_helper.YAPFTest):
       style.SetGlobalStyle(style.CreatePEP8Style())
       style.DEFAULT_STYLE = self.current_style
 
+  def testNoSplitBeforeFirstArgumentStyle1(self):
+    try:
+      pep8_no_split_before_first = style.CreatePEP8Style()
+      pep8_no_split_before_first['SPLIT_BEFORE_FIRST_ARGUMENT'] = False
+      pep8_no_split_before_first['SPLIT_BEFORE_NAMED_ASSIGNS'] = False
+      style.SetGlobalStyle(pep8_no_split_before_first)
+      formatted_code = textwrap.dedent("""\
+          # Example from in-code MustSplit comments
+          foo = outer_function_call(fitting_inner_function_call(inner_arg1, inner_arg2),
+                                    outer_arg1, outer_arg2)
+
+          foo = outer_function_call(
+              not_fitting_inner_function_call(inner_arg1, inner_arg2), outer_arg1,
+              outer_arg2)
+
+          # Examples Issue#424
+          a_super_long_version_of_print(argument1, argument2, argument3, argument4,
+                                        argument5, argument6, argument7)
+
+          CREDS_FILE = os.path.join(os.path.expanduser('~'),
+                                    'apis/super-secret-admin-creds.json')
+
+          # Examples Issue#556
+          i_take_a_lot_of_params(arg1, param1=very_long_expression1(),
+                                 param2=very_long_expression2(),
+                                 param3=very_long_expression3(),
+                                 param4=very_long_expression4())
+
+          # Examples Issue#590
+          plt.plot(numpy.linspace(0, 1, 10), numpy.linspace(0, 1, 10), marker="x",
+                   color="r")
+
+          plt.plot(veryverylongvariablename, veryverylongvariablename, marker="x",
+                   color="r")
+          """)
+      uwlines = yapf_test_helper.ParseAndUnwrap(formatted_code)
+      self.assertCodeEqual(formatted_code, reformatter.Reformat(uwlines))
+    finally:
+      style.SetGlobalStyle(style.CreatePEP8Style())
+      style.DEFAULT_STYLE = self.current_style
+
+  def testNoSplitBeforeFirstArgumentStyle2(self):
+    try:
+      pep8_no_split_before_first = style.CreatePEP8Style()
+      pep8_no_split_before_first['SPLIT_BEFORE_FIRST_ARGUMENT'] = False
+      pep8_no_split_before_first['SPLIT_BEFORE_NAMED_ASSIGNS'] = True
+      style.SetGlobalStyle(pep8_no_split_before_first)
+      formatted_code = textwrap.dedent("""\
+          # Examples Issue#556
+          i_take_a_lot_of_params(arg1,
+                                 param1=very_long_expression1(),
+                                 param2=very_long_expression2(),
+                                 param3=very_long_expression3(),
+                                 param4=very_long_expression4())
+
+          # Examples Issue#590
+          plt.plot(numpy.linspace(0, 1, 10),
+                   numpy.linspace(0, 1, 10),
+                   marker="x",
+                   color="r")
+
+          plt.plot(veryverylongvariablename,
+                   veryverylongvariablename,
+                   marker="x",
+                   color="r")
+          """)
+      uwlines = yapf_test_helper.ParseAndUnwrap(formatted_code)
+      self.assertCodeEqual(formatted_code, reformatter.Reformat(uwlines))
+    finally:
+      style.SetGlobalStyle(style.CreatePEP8Style())
+      style.DEFAULT_STYLE = self.current_style
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
If the option split_before_first_argument is set to false try to not split the line if not needed

Resolves #424, #556, #590, #684

# Examples
#### split_before_first_argument=False
```
[style]
split_before_first_argument=False
split_before_named_assigns=False
split_penalty_after_opening_bracket=300
```
```python
# Example from in-code MustSplit comments
foo = outer_function_call(fitting_inner_function_call(inner_arg1, inner_arg2),
                          outer_arg1, outer_arg2)

foo = outer_function_call(
    not_fitting_inner_function_call(inner_arg1, inner_arg2), outer_arg1,
    outer_arg2)

# Examples Issue#424
a_super_long_version_of_print(argument1, argument2, argument3, argument4,
                              argument5, argument6, argument7)

CREDS_FILE = os.path.join(os.path.expanduser('~'),
                          'apis/super-secret-admin-creds.json')

# Examples Issue#556
i_take_a_lot_of_params(arg1, param1=very_long_expression1(),
                       param2=very_long_expression2(),
                       param3=very_long_expression3(),
                       param4=very_long_expression4())

# Examples Issue#590
plt.plot(numpy.linspace(0, 1, 10), numpy.linspace(0, 1, 10), marker="x",
         color="r")

plt.plot(veryverylongvariablename, veryverylongvariablename, marker="x",
         color="r")
```
#### split_before_first_argument=True
```
[style]
split_before_first_argument=True
split_before_named_assigns=False
split_penalty_after_opening_bracket=300
```
```python
# Example from in-code MustSplit comments
foo = outer_function_call(
    fitting_inner_function_call(inner_arg1, inner_arg2), outer_arg1,
    outer_arg2)

foo = outer_function_call(
    not_fitting_inner_function_call(inner_arg1, inner_arg2), outer_arg1,
    outer_arg2)

# Examples Issue#424
a_super_long_version_of_print(
    argument1, argument2, argument3, argument4, argument5, argument6,
    argument7)

CREDS_FILE = os.path.join(
    os.path.expanduser('~'), 'apis/super-secret-admin-creds.json')

# Examples Issue#556
i_take_a_lot_of_params(
    arg1, param1=very_long_expression1(), param2=very_long_expression2(),
    param3=very_long_expression3(), param4=very_long_expression4())

# Examples Issue#590
plt.plot(
    numpy.linspace(0, 1, 10), numpy.linspace(0, 1, 10), marker="x", color="r")

plt.plot(
    veryverylongvariablename, veryverylongvariablename, marker="x", color="r")
```