### PR TITLE
ENH: slightly prefer split before named assigns

### DIFF
--- a/yapf/yapflib/unwrapped_line.py
+++ b/yapf/yapflib/unwrapped_line.py
@@ -526,6 +526,7 @@ def _SplitPenalty(prev_token, cur_token):
   """Return the penalty for breaking the line before the current token."""
   pval = prev_token.value
   cval = cur_token.value
+
   if pval == 'not':
     return split_penalty.UNBREAKABLE
 
@@ -567,6 +568,11 @@ def _SplitPenalty(prev_token, cur_token):
     return style.Get('SPLIT_PENALTY_AFTER_UNARY_OPERATOR')
   if pval == ',':
     # Breaking after a comma is fine, if need be.
+    # But slightly prefer split before named assign
+    if (format_token.Subtype.DEFAULT_OR_NAMED_ASSIGN in cur_token.subtypes or
+        format_token.Subtype.DEFAULT_OR_NAMED_ASSIGN_ARG_LIST in
+        cur_token.subtypes):
+      return -30
     return 0
   if pval == '**' or cval == '**':
     return split_penalty.STRONGLY_CONNECTED


### PR DESCRIPTION
Following up #691, this is an attempt to fix it by slightly favour split before named assign.
In the current state it only mitigates the effect in some cases:

```python
# now ok
def fooooooooooooo(aka=['aaaaaaaa', 'aaaaaaa', 'aaaa', 'aa', 'a'],
                   types=['double', 'bool'],
                   validator=some_looooooooooong_name):
    pass

# still bad
def fooooooooooooo(type01=['double'], type02=['double'], type03=['double'],
                   aka=['aaaaaaaa', 'aaaaaaa', 'aaaa', 'aa',
                        'a'], AAAAA=['double', 'bool'],
                   validator=some_looooooooooong_name):
    pass
``` 
Also it breaks a couple of tests that are right the way they are now. Example:
```python
  def f():
    if True:
      pytree_utils.InsertNodesBefore(
          _CreateCommentsFromPrefix(
              comment_prefix, comment_lineno, comment_column,
              standalone=True), ancestor_at_indent)  
```

@gwelymernans Any idea where/how to fix this? 