### PR TITLE
`spaces_before_comment` parsing for `--style-help`

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,3 +13,4 @@ Bill Wendling <morbo@google.com>
 Eli Bendersky <eliben@google.com>
 Sam Clegg <sbc@google.com>
 Łukasz Langa <ambv@fb.com>
+Oleg Butuzov <butuzov@made.ua>

--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -149,7 +149,7 @@ def main(argv):
         print('#', line and ' ' or '', line, sep='')
       option_value = style.Get(option)
       if isinstance(option_value, set) or isinstance(option_value, list):
-        option_value = ', '.join(option_value)
+        option_value = ', '.join(map(str, option_value))
       print(option.lower(), '=', option_value, sep='')
       print()
     return 0


### PR DESCRIPTION
This patch fixes issue observed running `yapf --style-help` with setting `spaces_before_comment` set to the range. See #723 for more information 