### PR TITLE
README: fix restructured text syntax

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -575,19 +575,19 @@ Knobs
     ``b`` in this code:
 
     .. code-block:: python
-
-    abcdef(
-        aReallyLongThing: int,
-        b: [Int,
-            Int])
+      
+      abcdef(
+          aReallyLongThing: int,
+          b: [Int,
+              Int])
    
     With the new knob this is split as:
 
     .. code-block:: python
-
-    abcdef(
-        aReallyLongThing: int,
-        b: [Int, Int])
+      
+      abcdef(
+          aReallyLongThing: int,
+          b: [Int, Int])
 
 ``SPLIT_BEFORE_BITWISE_OPERATOR``
     Set to ``True`` to prefer splitting before ``&``, ``|`` or ``^`` rather


### PR DESCRIPTION
The restructured text example  for `SPLIT_ALL_TOP_LEVEL_COMMA_SEPARATED_VALUES` is a bit broken:
 ![image](https://user-images.githubusercontent.com/521510/58687278-318e2400-83bc-11e9-8a80-2527b25638e9.png)

this repairs like this:

![image](https://user-images.githubusercontent.com/521510/58687330-57b3c400-83bc-11e9-8b89-373e598c998f.png)
