### PR TITLE
Catch/report `UnicodeDecodeError`s in `ReadFile`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
   unnecessary splits).
 ### Changed
 - Set `INDENT_DICTIONARY_VALUE` for Google style.
+- Catch and report `UnicodeDecodeError` exceptions.
 ### Fixed
 - `BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF=False` wasn't honored because the
   number of newlines was erroneously calculated beforehand.

--- a/yapf/yapflib/yapf_api.py
+++ b/yapf/yapflib/yapf_api.py
@@ -202,6 +202,12 @@ def ReadFile(filename, logger=None):
     if logger:
       logger(err)
     raise
+  except UnicodeDecodeError as err:  # pragma: no cover
+    if logger:
+      logger("Could not parse {}! Consider excluding this file with --exclude."
+             .format(filename))
+      logger(err)
+    raise
 
 
 def _SplitSemicolons(uwlines):

--- a/yapf/yapflib/yapf_api.py
+++ b/yapf/yapflib/yapf_api.py
@@ -204,8 +204,8 @@ def ReadFile(filename, logger=None):
     raise
   except UnicodeDecodeError as err:  # pragma: no cover
     if logger:
-      logger("Could not parse {}! Consider excluding this file with --exclude."
-             .format(filename))
+      logger('Could not parse %s! Consider excluding this file with --exclude.',
+             filename)
       logger(err)
     raise
 


### PR DESCRIPTION
Addresses https://github.com/google/yapf/issues/736.