### PR TITLE
Set JOIN_MULTIPLE_LINES = False in google style

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@
   unnecessary splits).
 ### Changed
 - Set `INDENT_DICTIONARY_VALUE` for Google style.
+- Set `JOIN_MULTIPLE_LINES = False` for Google style.
 ### Fixed
 - `BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF=False` wasn't honored because the
   number of newlines was erroneously calculated beforehand.

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -404,6 +404,7 @@ def CreateGoogleStyle():
   style['INDENT_WIDTH'] = 4
   style['I18N_COMMENT'] = r'#\..*'
   style['I18N_FUNCTION_CALL'] = ['N_', '_']
+  style['JOIN_MULTIPLE_LINES'] = False
   style['SPACE_BETWEEN_ENDING_COMMA_AND_CLOSING_BRACKET'] = False
   style['SPLIT_BEFORE_BITWISE_OPERATOR'] = False
   style['SPLIT_BEFORE_DICT_SET_GENERATOR'] = False
@@ -419,7 +420,6 @@ def CreateChromiumStyle():
   style['ALLOW_SPLIT_BEFORE_DEFAULT_OR_NAMED_ASSIGNS'] = False
   style['INDENT_DICTIONARY_VALUE'] = True
   style['INDENT_WIDTH'] = 2
-  style['JOIN_MULTIPLE_LINES'] = False
   style['SPLIT_BEFORE_BITWISE_OPERATOR'] = True
   style['SPLIT_BEFORE_DOT'] = True
   style['SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN'] = True


### PR DESCRIPTION
IIUC, this is more likely to make the output compliant with the google
style guide[1], though in some cases it is stricter than that
document requires.
Specifically this example from the "No" section would be fixed only
after this change:
```
if foo: bar(foo)
else: baz(foo)
```

But this example from the "Yes" section will also be modified:
```
if foo: bar(foo)
```

I think eliminating one way in which the formatter produes
style-guide-violating code is an improvement.

[1] https://github.com/google/styleguide/blob/gh-pages/pyguide.md#314-statements