### PR TITLE
Look for style file / setup config at root, add tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,8 @@
 ### Fixed
 - Format subscript lists so that splits are essentially free after a comma.
 - Don't add a space between a string and its subscript.
+- Extend discovery of '.style.yapf' & 'setup.cfg' files to search the root
+  directory as well.
 
 ## [0.28.0] 2019-07-11
 ### Added

--- a/yapf/yapflib/file_resources.py
+++ b/yapf/yapflib/file_resources.py
@@ -97,10 +97,10 @@ def GetDefaultStyleForDir(dirname, default_style=style.DEFAULT_STYLE):
         if config.has_section('yapf'):
           return config_file
 
-    dirname = os.path.dirname(dirname)
     if (not dirname or not os.path.basename(dirname) or
         dirname == os.path.abspath(os.path.sep)):
       break
+    dirname = os.path.dirname(dirname)
 
   global_file = os.path.expanduser(style.GLOBAL_STYLE)
   if os.path.exists(global_file):

--- a/yapftests/file_resources_test.py
+++ b/yapftests/file_resources_test.py
@@ -37,12 +37,12 @@ def _restore_working_dir():
 
 @contextlib.contextmanager
 def _exists_mocked_in_module(module, mock_implementation):
-    unmocked_exists = getattr(module, 'exists')
-    setattr(module, 'exists', mock_implementation)
-    try:
-        yield
-    finally:
-        setattr(module, 'exists', unmocked_exists)
+  unmocked_exists = getattr(module, 'exists')
+  setattr(module, 'exists', mock_implementation)
+  try:
+    yield
+  finally:
+    setattr(module, 'exists', unmocked_exists)
 
 
 class GetExcludePatternsForDir(unittest.TestCase):
@@ -124,8 +124,10 @@ class GetDefaultStyleForDirTest(unittest.TestCase):
 
     # Fake placing only a style file at the root by mocking `os.path.exists`.
     style_file = os.path.join(rootdir, '.style.yapf')
+
     def mock_exists_implementation(path):
       return path == style_file
+
     with _exists_mocked_in_module(file_resources.os.path,
                                   mock_exists_implementation):
       # Both files should find the style file at the root.

--- a/yapftests/file_resources_test.py
+++ b/yapftests/file_resources_test.py
@@ -35,6 +35,7 @@ def _restore_working_dir():
   finally:
     os.chdir(curdir)
 
+
 @contextlib.contextmanager
 def _exists_mocked_in_module(module, mock_implementation):
   unmocked_exists = getattr(module, 'exists')


### PR DESCRIPTION
  - We encountered a weird phenonemon when building containers with setup.cfg placed at the container root, and the yapf command fired on a subdirectory of root.
  - Appears as though the traversal to root breaks one step too early in the current implementation. Tiny fix; adds a test.
  - Also adds a few tests to test discovery of styles via setup.cfg
  - Thanks to sendittovignesh@gmail.com and matthewwillian@gmail.com for the discovery & diagnosis of the issue!