### PR TITLE
Add ignore rule for PyCharm (.idea)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@
 /dist
 /.tox
 /yapf.egg-info
+
+/.idea
+


### PR DESCRIPTION
For developers use PyCharm it would be nice to exclude the files under .idea/