### PR TITLE
Update chromium style to match what's used in Chromium

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,3 +1,2 @@
 [style]
-# YAPF uses the chromium style
-based_on_style = chromium
+based_on_style = yapf

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,10 @@
 # All notable changes to this project will be documented in this file.
 # This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [vNext]-
+### Changed
+- Renamed "chromium" style to "yapf". Chromium will now use PEP-8 directly.
+
 ## [0.29.0] 2019-11-28
 ### Added
 - Add the `--quiet` flag to suppress output. The return code is 1 if there are

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -27,9 +27,8 @@ use Github pull requests for this purpose.
 YAPF coding style
 -----------------
 
-YAPF follows the `Chromium Python Style Guide
-<https://www.chromium.org/chromium-os/python-style-guidelines>`_. It's the same
-as the Google Python Style guide with two exceptions:
+YAPF follows the `Google Python Style Guide
+<https://google.github.io/styleguide/pyguide.html>`_ with two exceptions:
 
 - 2 spaces for indentation rather than 4.
 - CamelCase for function and method names rather than snake_case.

--- a/README.rst
+++ b/README.rst
@@ -178,8 +178,8 @@ with a ``[yapf]`` heading. For example:
 
 The ``based_on_style`` setting determines which of the predefined styles this
 custom style is based on (think of it like subclassing). Four
-styles are predefined: ``pep8`` (default), ``chromium``, ``google`` and 
-``facebook`` (see ``_STYLE_NAME_TO_FACTORY`` in style.py_).
+styles are predefined: ``pep8`` (default), ``google`` and ``facebook`` (see
+``_STYLE_NAME_TO_FACTORY`` in style.py_).
 
 .. _style.py: https://github.com/google/yapf/blob/master/yapf/yapflib/style.py#L445
 
@@ -188,9 +188,9 @@ example:
 
 .. code-block:: shell
 
-    --style='{based_on_style: chromium, indent_width: 4}'
+    --style='{based_on_style: pep8, indent_width: 2}'
 
-This will take the ``chromium`` base style and modify it to have four space
+This will take the ``pep8`` base style and modify it to have two space
 indentations.
 
 YAPF will search for the formatting style in the following manner:

--- a/README.rst
+++ b/README.rst
@@ -178,8 +178,8 @@ with a ``[yapf]`` heading. For example:
 
 The ``based_on_style`` setting determines which of the predefined styles this
 custom style is based on (think of it like subclassing). Four
-styles are predefined: ``pep8`` (default), ``google`` and ``facebook`` (see
-``_STYLE_NAME_TO_FACTORY`` in style.py_).
+styles are predefined: ``pep8`` (default), ``google``, ``yapf``, and ``facebook``
+(see ``_STYLE_NAME_TO_FACTORY`` in style.py_).
 
 .. _style.py: https://github.com/google/yapf/blob/master/yapf/yapflib/style.py#L445
 

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -432,11 +432,10 @@ def CreateGoogleStyle():
   return style
 
 
-def CreateChromiumStyle():
+def CreateYapfStyle():
   style = CreateGoogleStyle()
   style['ALLOW_MULTILINE_DICTIONARY_KEYS'] = True
   style['ALLOW_SPLIT_BEFORE_DEFAULT_OR_NAMED_ASSIGNS'] = False
-  style['INDENT_DICTIONARY_VALUE'] = True
   style['INDENT_WIDTH'] = 2
   style['SPLIT_BEFORE_BITWISE_OPERATOR'] = True
   style['SPLIT_BEFORE_DOT'] = True
@@ -463,16 +462,16 @@ def CreateFacebookStyle():
 
 _STYLE_NAME_TO_FACTORY = dict(
     pep8=CreatePEP8Style,
-    chromium=CreateChromiumStyle,
     google=CreateGoogleStyle,
     facebook=CreateFacebookStyle,
+    yapf=CreateYapfStyle,
 )
 
 _DEFAULT_STYLE_TO_FACTORY = [
-    (CreateChromiumStyle(), CreateChromiumStyle),
     (CreateFacebookStyle(), CreateFacebookStyle),
     (CreateGoogleStyle(), CreateGoogleStyle),
     (CreatePEP8Style(), CreatePEP8Style),
+    (CreateYapfStyle(), CreateYapfStyle),
 ]
 
 

--- a/yapftests/blank_line_calculator_test.py
+++ b/yapftests/blank_line_calculator_test.py
@@ -27,7 +27,7 @@ class BasicBlankLineCalculatorTest(yapf_test_helper.YAPFTest):
 
   @classmethod
   def setUpClass(cls):
-    style.SetGlobalStyle(style.CreateChromiumStyle())
+    style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testDecorators(self):
     unformatted_code = textwrap.dedent("""\

--- a/yapftests/format_decision_state_test.py
+++ b/yapftests/format_decision_state_test.py
@@ -28,7 +28,7 @@ class FormatDecisionStateTest(yapf_test_helper.YAPFTest):
 
   @classmethod
   def setUpClass(cls):
-    style.SetGlobalStyle(style.CreateChromiumStyle())
+    style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testSimpleFunctionDefWithNoSplitting(self):
     code = textwrap.dedent(r"""

--- a/yapftests/main_test.py
+++ b/yapftests/main_test.py
@@ -113,12 +113,12 @@ class MainTest(unittest.TestCase):
 
   def testEchoInputWithStyle(self):
     code = 'def f(a = 1):\n    return 2*a\n'
-    chromium_code = 'def f(a=1):\n  return 2 * a\n'
+    yapf_code = 'def f(a=1):\n  return 2 * a\n'
     with patched_input(code):
       with captured_output() as (out, _):
-        ret = yapf.main(['-', '--style=chromium'])
+        ret = yapf.main(['-', '--style=yapf'])
         self.assertEqual(ret, 0)
-        self.assertEqual(out.getvalue(), chromium_code)
+        self.assertEqual(out.getvalue(), yapf_code)
 
   def testEchoBadInput(self):
     bad_syntax = '  a = 1\n'

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -27,7 +27,7 @@ class BasicReformatterTest(yapf_test_helper.YAPFTest):
 
   @classmethod
   def setUpClass(cls):
-    style.SetGlobalStyle(style.CreateChromiumStyle())
+    style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testSplittingAllArgs(self):
     style.SetGlobalStyle(
@@ -262,7 +262,7 @@ class BasicReformatterTest(yapf_test_helper.YAPFTest):
     try:
       style.SetGlobalStyle(
           style.CreateStyleFromConfig(
-              '{based_on_style: chromium, indent_blank_lines: true}'))
+              '{based_on_style: yapf, indent_blank_lines: true}'))
       unformatted_code = textwrap.dedent("""\
           class foo(object):
 
@@ -288,7 +288,7 @@ class foo(object):\n  \n  def foobar(self):\n    \n    pass\n  \n  def barfoo(se
       self.assertCodeEqual(expected_formatted_code,
                            reformatter.Reformat(uwlines))
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
     unformatted_code, expected_formatted_code = (expected_formatted_code,
                                                  unformatted_code)
@@ -1802,7 +1802,7 @@ class A(object):
     try:
       style.SetGlobalStyle(
           style.CreateStyleFromConfig(
-              '{based_on_style: chromium, allow_multiline_lambdas: true}'))
+              '{based_on_style: yapf, allow_multiline_lambdas: true}'))
       unformatted_code = textwrap.dedent("""\
           class SomeClass(object):
             do_something = True
@@ -1830,12 +1830,12 @@ class A(object):
       self.assertCodeEqual(expected_formatted_code,
                            reformatter.Reformat(uwlines))
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testMultilineDictionaryKeys(self):
     try:
       style.SetGlobalStyle(
-          style.CreateStyleFromConfig('{based_on_style: chromium, '
+          style.CreateStyleFromConfig('{based_on_style: yapf, '
                                       'allow_multiline_dictionary_keys: true}'))
       unformatted_code = textwrap.dedent("""\
           MAP_WITH_LONG_KEYS = {
@@ -1862,7 +1862,7 @@ class A(object):
       self.assertCodeEqual(expected_formatted_code,
                            reformatter.Reformat(uwlines))
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testStableDictionaryFormatting(self):
     try:
@@ -1891,7 +1891,7 @@ class A(object):
       reformatted_code = reformatter.Reformat(uwlines)
       self.assertCodeEqual(code, reformatted_code)
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testStableInlinedDictionaryFormatting(self):
     try:
@@ -1918,7 +1918,7 @@ class A(object):
       reformatted_code = reformatter.Reformat(uwlines)
       self.assertCodeEqual(expected_formatted_code, reformatted_code)
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testDontSplitKeywordValueArguments(self):
     unformatted_code = textwrap.dedent("""\
@@ -1987,7 +1987,7 @@ class A(object):
       reformatted_code = reformatter.Reformat(uwlines)
       self.assertCodeEqual(code, reformatted_code)
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testNotSplittingAfterSubscript(self):
     unformatted_code = textwrap.dedent("""\
@@ -2059,7 +2059,7 @@ class A(object):
     try:
       style.SetGlobalStyle(
           style.CreateStyleFromConfig(
-              '{based_on_style: chromium, '
+              '{based_on_style: yapf, '
               'split_arguments_when_comma_terminated: True}'))
       unformatted_code = textwrap.dedent("""\
           function_name(argument_name_1=1, argument_name_2=2, argument_name_3=3)
@@ -2108,7 +2108,7 @@ class A(object):
       reformatted_code = reformatter.Reformat(uwlines)
       self.assertCodeEqual(expected_formatted_code, reformatted_code)
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testImportAsList(self):
     code = textwrap.dedent("""\
@@ -2374,7 +2374,7 @@ class A(object):
     try:
       style.SetGlobalStyle(
           style.CreateStyleFromConfig(
-              '{based_on_style: chromium, '
+              '{based_on_style: yapf, '
               'blank_line_before_class_docstring: True}'))
       unformatted_code = textwrap.dedent('''\
           class A:
@@ -2402,7 +2402,7 @@ class A(object):
       self.assertCodeEqual(expected_formatted_code,
                            reformatter.Reformat(uwlines))
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testBlankLineBeforeModuleDocstring(self):
     unformatted_code = textwrap.dedent('''\
@@ -2455,7 +2455,7 @@ class A(object):
       self.assertCodeEqual(expected_formatted_code,
                            reformatter.Reformat(uwlines))
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testTupleCohesion(self):
     unformatted_code = textwrap.dedent("""\
@@ -2541,7 +2541,7 @@ my_dict = {
     try:
       style.SetGlobalStyle(
           style.CreateStyleFromConfig(
-              '{based_on_style: chromium, split_before_first_argument: True}'))
+              '{based_on_style: yapf, split_before_first_argument: True}'))
       unformatted_code = textwrap.dedent("""\
           a_very_long_function_name("long string with formatting {0:s}".format(
               "mystring"))
@@ -2554,14 +2554,14 @@ my_dict = {
       self.assertCodeEqual(expected_formatted_code,
                            reformatter.Reformat(uwlines))
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testSplittingBeforeFirstArgumentOnFunctionDefinition(self):
     """Tests split_before_first_argument on a function definition."""
     try:
       style.SetGlobalStyle(
           style.CreateStyleFromConfig(
-              '{based_on_style: chromium, split_before_first_argument: True}'))
+              '{based_on_style: yapf, split_before_first_argument: True}'))
       unformatted_code = textwrap.dedent("""\
           def _GetNumberOfSecondsFromElements(year, month, day, hours,
                                               minutes, seconds, microseconds):
@@ -2576,14 +2576,14 @@ my_dict = {
       self.assertCodeEqual(expected_formatted_code,
                            reformatter.Reformat(uwlines))
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testSplittingBeforeFirstArgumentOnCompoundStatement(self):
     """Tests split_before_first_argument on a compound statement."""
     try:
       style.SetGlobalStyle(
           style.CreateStyleFromConfig(
-              '{based_on_style: chromium, split_before_first_argument: True}'))
+              '{based_on_style: yapf, split_before_first_argument: True}'))
       unformatted_code = textwrap.dedent("""\
           if (long_argument_name_1 == 1 or
               long_argument_name_2 == 2 or
@@ -2600,14 +2600,14 @@ my_dict = {
       self.assertCodeEqual(expected_formatted_code,
                            reformatter.Reformat(uwlines))
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testCoalesceBracketsOnDict(self):
     """Tests coalesce_brackets on a dictionary."""
     try:
       style.SetGlobalStyle(
           style.CreateStyleFromConfig(
-              '{based_on_style: chromium, coalesce_brackets: True}'))
+              '{based_on_style: yapf, coalesce_brackets: True}'))
       unformatted_code = textwrap.dedent("""\
           date_time_values = (
               {
@@ -2634,13 +2634,13 @@ my_dict = {
       self.assertCodeEqual(expected_formatted_code,
                            reformatter.Reformat(uwlines))
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testSplitAfterComment(self):
     try:
       style.SetGlobalStyle(
           style.CreateStyleFromConfig(
-              '{based_on_style: chromium, coalesce_brackets: True, '
+              '{based_on_style: yapf, coalesce_brackets: True, '
               'dedent_closing_brackets: true}'))
       code = textwrap.dedent("""\
           if __name__ == "__main__":
@@ -2653,7 +2653,7 @@ my_dict = {
       uwlines = yapf_test_helper.ParseAndUnwrap(code)
       self.assertCodeEqual(code, reformatter.Reformat(uwlines))
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   @unittest.skipUnless(not py3compat.PY3, 'Requires Python 2.7')
   def testAsyncAsNonKeyword(self):
@@ -2675,12 +2675,12 @@ my_dict = {
       uwlines = yapf_test_helper.ParseAndUnwrap(code)
       self.assertCodeEqual(code, reformatter.Reformat(uwlines, verify=False))
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testDisableEndingCommaHeuristic(self):
     try:
       style.SetGlobalStyle(
-          style.CreateStyleFromConfig('{based_on_style: chromium,'
+          style.CreateStyleFromConfig('{based_on_style: yapf,'
                                       ' disable_ending_comma_heuristic: True}'))
 
       code = """\
@@ -2689,12 +2689,12 @@ x = [1, 2, 3, 4, 5, 6, 7,]
       uwlines = yapf_test_helper.ParseAndUnwrap(code)
       self.assertCodeEqual(code, reformatter.Reformat(uwlines))
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testDedentClosingBracketsWithTypeAnnotationExceedingLineLength(self):
     try:
       style.SetGlobalStyle(
-          style.CreateStyleFromConfig('{based_on_style: chromium,'
+          style.CreateStyleFromConfig('{based_on_style: yapf,'
                                       ' dedent_closing_brackets: True}'))
       unformatted_code = textwrap.dedent("""\
                 def function(first_argument_xxxxxxxxxxxxxxxx=(0,), second_argument=None) -> None:
@@ -2720,12 +2720,12 @@ x = [1, 2, 3, 4, 5, 6, 7,]
       self.assertCodeEqual(expected_formatted_code,
                            reformatter.Reformat(uwlines))
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testIndentClosingBracketsWithTypeAnnotationExceedingLineLength(self):
     try:
       style.SetGlobalStyle(
-          style.CreateStyleFromConfig('{based_on_style: chromium,'
+          style.CreateStyleFromConfig('{based_on_style: yapf,'
                                       ' indent_closing_brackets: True}'))
       unformatted_code = textwrap.dedent("""\
                 def function(first_argument_xxxxxxxxxxxxxxxx=(0,), second_argument=None) -> None:
@@ -2751,12 +2751,12 @@ x = [1, 2, 3, 4, 5, 6, 7,]
       self.assertCodeEqual(expected_formatted_code,
                            reformatter.Reformat(uwlines))
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testIndentClosingBracketsInFunctionCall(self):
     try:
       style.SetGlobalStyle(
-          style.CreateStyleFromConfig('{based_on_style: chromium,'
+          style.CreateStyleFromConfig('{based_on_style: yapf,'
                                       ' indent_closing_brackets: True}'))
       unformatted_code = textwrap.dedent("""\
                 def function(first_argument_xxxxxxxxxxxxxxxx=(0,), second_argument=None, third_and_final_argument=True):
@@ -2784,12 +2784,12 @@ x = [1, 2, 3, 4, 5, 6, 7,]
       self.assertCodeEqual(expected_formatted_code,
                            reformatter.Reformat(uwlines))
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testIndentClosingBracketsInTuple(self):
     try:
       style.SetGlobalStyle(
-          style.CreateStyleFromConfig('{based_on_style: chromium,'
+          style.CreateStyleFromConfig('{based_on_style: yapf,'
                                       ' indent_closing_brackets: True}'))
       unformatted_code = textwrap.dedent("""\
                 def function():
@@ -2817,12 +2817,12 @@ x = [1, 2, 3, 4, 5, 6, 7,]
       self.assertCodeEqual(expected_formatted_code,
                            reformatter.Reformat(uwlines))
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testIndentClosingBracketsInList(self):
     try:
       style.SetGlobalStyle(
-          style.CreateStyleFromConfig('{based_on_style: chromium,'
+          style.CreateStyleFromConfig('{based_on_style: yapf,'
                                       ' indent_closing_brackets: True}'))
       unformatted_code = textwrap.dedent("""\
                 def function():
@@ -2850,12 +2850,12 @@ x = [1, 2, 3, 4, 5, 6, 7,]
       self.assertCodeEqual(expected_formatted_code,
                            reformatter.Reformat(uwlines))
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testIndentClosingBracketsInDict(self):
     try:
       style.SetGlobalStyle(
-          style.CreateStyleFromConfig('{based_on_style: chromium,'
+          style.CreateStyleFromConfig('{based_on_style: yapf,'
                                       ' indent_closing_brackets: True}'))
       unformatted_code = textwrap.dedent("""\
                 def function():
@@ -2889,7 +2889,7 @@ x = [1, 2, 3, 4, 5, 6, 7,]
       self.assertCodeEqual(expected_formatted_code,
                            reformatter.Reformat(uwlines))
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testMultipleDictionariesInList(self):
     unformatted_code = """\

--- a/yapftests/reformatter_buganizer_test.py
+++ b/yapftests/reformatter_buganizer_test.py
@@ -26,7 +26,7 @@ class BuganizerFixes(yapf_test_helper.YAPFTest):
 
   @classmethod
   def setUpClass(cls):
-    style.SetGlobalStyle(style.CreateChromiumStyle())
+    style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testB137580392(self):
     code = """\
@@ -1700,7 +1700,7 @@ class _():
 
     try:
       style.SetGlobalStyle(
-          style.CreateStyleFromConfig('{based_on_style: chromium, '
+          style.CreateStyleFromConfig('{based_on_style: yapf, '
                                       'split_before_logical_operator: True}'))
       code = textwrap.dedent("""\
           class foo():
@@ -1722,7 +1722,7 @@ class _():
       uwlines = yapf_test_helper.ParseAndUnwrap(code)
       self.assertCodeEqual(code, reformatter.Reformat(uwlines))
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testB22527411(self):
     unformatted_code = textwrap.dedent("""\
@@ -1878,7 +1878,7 @@ class _():
       style.SetGlobalStyle(style.CreatePEP8Style())
       self.assertCodeEqual(code, reformatter.Reformat(uwlines))
     finally:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
   def testB19353268(self):
     code = textwrap.dedent("""\

--- a/yapftests/reformatter_style_config_test.py
+++ b/yapftests/reformatter_style_config_test.py
@@ -29,7 +29,7 @@ class TestsForStyleConfig(yapf_test_helper.YAPFTest):
 
   def testSetGlobalStyle(self):
     try:
-      style.SetGlobalStyle(style.CreateChromiumStyle())
+      style.SetGlobalStyle(style.CreateYapfStyle())
       unformatted_code = textwrap.dedent(u"""\
           for i in range(5):
            print('bar')

--- a/yapftests/split_penalty_test.py
+++ b/yapftests/split_penalty_test.py
@@ -36,7 +36,7 @@ class SplitPenaltyTest(yapf_test_helper.YAPFTest):
 
   @classmethod
   def setUpClass(cls):
-    style.SetGlobalStyle(style.CreateChromiumStyle())
+    style.SetGlobalStyle(style.CreateYapfStyle())
 
   def _ParseAndComputePenalties(self, code, dumptree=False):
     """Parses the code and computes split penalties.

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -43,7 +43,7 @@ class FormatCodeTest(yapf_test_helper.YAPFTest):
 
   def _Check(self, unformatted_code, expected_formatted_code):
     formatted_code, _ = yapf_api.FormatCode(
-        unformatted_code, style_config='chromium')
+        unformatted_code, style_config='yapf')
     self.assertCodeEqual(expected_formatted_code, formatted_code)
 
   def testSimple(self):
@@ -95,7 +95,7 @@ class FormatFileTest(unittest.TestCase):
         if True:
             pass
         """)
-    expected_formatted_code_chromium = textwrap.dedent(u"""\
+    expected_formatted_code_yapf = textwrap.dedent(u"""\
         if True:
           pass
         """)
@@ -103,9 +103,8 @@ class FormatFileTest(unittest.TestCase):
       formatted_code, _, _ = yapf_api.FormatFile(filepath, style_config='pep8')
       self.assertCodeEqual(expected_formatted_code_pep8, formatted_code)
 
-      formatted_code, _, _ = yapf_api.FormatFile(
-          filepath, style_config='chromium')
-      self.assertCodeEqual(expected_formatted_code_chromium, formatted_code)
+      formatted_code, _, _ = yapf_api.FormatFile(filepath, style_config='yapf')
+      self.assertCodeEqual(expected_formatted_code_yapf, formatted_code)
 
   def testDisableLinesPattern(self):
     unformatted_code = textwrap.dedent(u"""\
@@ -348,8 +347,7 @@ class FormatFileTest(unittest.TestCase):
         ]
         """)
     with utils.TempFileContents(self.test_tmpdir, code) as filepath:
-      formatted_code, _, _ = yapf_api.FormatFile(
-          filepath, style_config='chromium')
+      formatted_code, _, _ = yapf_api.FormatFile(filepath, style_config='yapf')
       self.assertCodeEqual(code, formatted_code)
 
   def testDisabledWithPrecedingText(self):
@@ -368,15 +366,13 @@ class FormatFileTest(unittest.TestCase):
         ]
         """)
     with utils.TempFileContents(self.test_tmpdir, code) as filepath:
-      formatted_code, _, _ = yapf_api.FormatFile(
-          filepath, style_config='chromium')
+      formatted_code, _, _ = yapf_api.FormatFile(filepath, style_config='yapf')
       self.assertCodeEqual(code, formatted_code)
 
   def testCRLFLineEnding(self):
     code = u'class _():\r\n  pass\r\n'
     with utils.TempFileContents(self.test_tmpdir, code) as filepath:
-      formatted_code, _, _ = yapf_api.FormatFile(
-          filepath, style_config='chromium')
+      formatted_code, _, _ = yapf_api.FormatFile(filepath, style_config='yapf')
       self.assertCodeEqual(code, formatted_code)
 
 
@@ -489,7 +485,7 @@ class CommandLineTest(unittest.TestCase):
         """)
     self.assertYapfReformats(unformatted_code, expected_formatted_code)
 
-  def testSetChromiumStyle(self):
+  def testSetYapfStyle(self):
     unformatted_code = textwrap.dedent("""\
         def foo(): # trail
             x = 37
@@ -501,9 +497,9 @@ class CommandLineTest(unittest.TestCase):
     self.assertYapfReformats(
         unformatted_code,
         expected_formatted_code,
-        extra_options=['--style=chromium'])
+        extra_options=['--style=yapf'])
 
-  def testSetCustomStyleBasedOnChromium(self):
+  def testSetCustomStyleBasedOnYapf(self):
     unformatted_code = textwrap.dedent("""\
         def foo(): # trail
             x = 37
@@ -514,7 +510,7 @@ class CommandLineTest(unittest.TestCase):
         """)
     style_file = textwrap.dedent(u'''\
         [style]
-        based_on_style = chromium
+        based_on_style = yapf
         spaces_before_comment = 4
         ''')
     with utils.TempFileContents(self.test_tmpdir, style_file) as stylepath:
@@ -1150,7 +1146,7 @@ x = {
     self.assertYapfReformats(
         unformatted_code,
         expected_formatted_code,
-        extra_options=['--lines', '1-1', '--style', 'chromium'])
+        extra_options=['--lines', '1-1', '--style', 'yapf'])
 
   def testMultilineCommentFormattingDisabled(self):
     unformatted_code = textwrap.dedent("""\
@@ -1184,7 +1180,7 @@ x = {
     self.assertYapfReformats(
         unformatted_code,
         expected_formatted_code,
-        extra_options=['--lines', '1-1', '--style', 'chromium'])
+        extra_options=['--lines', '1-1', '--style', 'yapf'])
 
   def testTrailingCommentsWithDisabledFormatting(self):
     unformatted_code = textwrap.dedent("""\
@@ -1204,7 +1200,7 @@ x = {
     self.assertYapfReformats(
         unformatted_code,
         expected_formatted_code,
-        extra_options=['--lines', '1-1', '--style', 'chromium'])
+        extra_options=['--lines', '1-1', '--style', 'yapf'])
 
   def testUseTabs(self):
     unformatted_code = """\
@@ -1219,7 +1215,7 @@ def foo_function():
 """
     style_contents = u"""\
 [style]
-based_on_style = chromium
+based_on_style = yapf
 USE_TABS = true
 INDENT_WIDTH=1
 """
@@ -1243,7 +1239,7 @@ def f():
 """
     style_contents = u"""\
 [style]
-based_on_style = chromium
+based_on_style = yapf
 USE_TABS = true
 INDENT_WIDTH=1
 """
@@ -1268,7 +1264,7 @@ def foo_function(arg1, arg2,
 """
     style_contents = u"""\
 [style]
-based_on_style = chromium
+based_on_style = yapf
 USE_TABS = true
 COLUMN_LIMIT=32
 INDENT_WIDTH=4
@@ -1296,7 +1292,7 @@ def foo_function(arg1, arg2,
 """
     style_contents = u"""\
 [style]
-based_on_style = chromium
+based_on_style = yapf
 USE_TABS = true
 COLUMN_LIMIT=32
 INDENT_WIDTH=4
@@ -1393,7 +1389,7 @@ CONTINUATION_ALIGN_STYLE = valign-right
     self.assertYapfReformats(
         unformatted_code,
         expected_formatted_code,
-        extra_options=['--style', 'chromium', '--lines', '1-1'])
+        extra_options=['--style', 'yapf', '--lines', '1-1'])
 
   @unittest.skipUnless(py3compat.PY36, 'Requires Python 3.6')
   def testNoSpacesAroundBinaryOperators(self):
@@ -1443,7 +1439,7 @@ a = [
     self.assertYapfReformats(
         unformatted_code,
         expected_formatted_code,
-        extra_options=['--style', 'chromium', '--lines', '1-100'])
+        extra_options=['--style', 'yapf', '--lines', '1-100'])
 
 
 class BadInputTest(unittest.TestCase):


### PR DESCRIPTION
Adds a "YAPF" style in order to avoid reformatting the YAPF codebase
and updating test expectations

Relevant Chromium style discussion:
https://groups.google.com/a/chromium.org/g/chromium-dev/c/RcJgJdkNIdg/discussion