### PR TITLE
extend CONTINUATION_ALIGN_STYLE for space indentation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,8 @@
   values, not comments, which may be associated with the current line.
 - Don't over-indent a parameter list when not needed. But make sure it is
   properly indented so that it doesn't collide with the lines afterwards.
+- `CONTINUATION_ALIGN_STYLE` with `FIXED` or `VALIGN-RIGHT` now works with
+  space indentation.
 
 ## [0.29.0] 2019-11-28
 ### Added

--- a/README.rst
+++ b/README.rst
@@ -434,14 +434,11 @@ Knobs
     - ``SPACE``: Use spaces for continuation alignment. This is default
       behavior.
     - ``FIXED``: Use fixed number (CONTINUATION_INDENT_WIDTH) of columns
-      (ie: CONTINUATION_INDENT_WIDTH/INDENT_WIDTH tabs) for continuation
-      alignment.
-    - ``VALIGN-RIGHT``: Vertically align continuation lines with indent
-      characters. Slightly right (one more indent character) if cannot
+      (ie: CONTINUATION_INDENT_WIDTH/INDENT_WIDTH tabs or CONTINUATION_INDENT_WIDTH
+      spaces) for continuation alignment.
+    - ``VALIGN-RIGHT``: Vertically align continuation lines to multiple of
+      INDENT_WIDTH columns. Slightly right (one tab or a few spaces) if cannot
       vertically align continuation lines with indent characters.
-
-      For options ``FIXED``, and ``VALIGN-RIGHT`` are only available when
-      ``USE_TABS`` is enabled.
 
 ``CONTINUATION_INDENT_WIDTH``
     Indent width used for line continuations.

--- a/yapf/yapflib/format_token.py
+++ b/yapf/yapflib/format_token.py
@@ -62,25 +62,21 @@ class Subtype(object):
   PARAMETER_STOP = 26
 
 
-def _TabbedContinuationAlignPadding(spaces, align_style, tab_width,
-                                    continuation_indent_width):
+def _TabbedContinuationAlignPadding(spaces, align_style, tab_width):
   """Build padding string for continuation alignment in tabbed indentation.
 
   Arguments:
     spaces: (int) The number of spaces to place before the token for alignment.
     align_style: (str) The alignment style for continuation lines.
     tab_width: (int) Number of columns of each tab character.
-    continuation_indent_width: (int) Indent columns for line continuations.
 
   Returns:
     A padding string for alignment with style specified by align_style option.
   """
-  if align_style == 'FIXED':
+  if align_style in ('FIXED', 'VALIGN-RIGHT'):
     if spaces > 0:
-      return '\t' * int(continuation_indent_width / tab_width)
+      return '\t' * int((spaces + tab_width - 1) / tab_width)
     return ''
-  elif align_style == 'VALIGN-RIGHT':
-    return '\t' * int((spaces + tab_width - 1) / tab_width)
   return ' ' * spaces
 
 
@@ -171,7 +167,7 @@ class FormatToken(object):
       if newlines_before > 0:
         indent_before = '\t' * indent_level + _TabbedContinuationAlignPadding(
             spaces, style.Get('CONTINUATION_ALIGN_STYLE'),
-            style.Get('INDENT_WIDTH'), style.Get('CONTINUATION_INDENT_WIDTH'))
+            style.Get('INDENT_WIDTH'))
       else:
         indent_before = '\t' * indent_level + ' ' * spaces
     else:

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -123,14 +123,11 @@ _STYLE_HELP = dict(
 
       - SPACE: Use spaces for continuation alignment. This is default behavior.
       - FIXED: Use fixed number (CONTINUATION_INDENT_WIDTH) of columns
-        (ie: CONTINUATION_INDENT_WIDTH/INDENT_WIDTH tabs) for continuation
-        alignment.
-      - VALIGN-RIGHT: Vertically align continuation lines with indent
-        characters. Slightly right (one more indent character) if cannot
-        vertically align continuation lines with indent characters.
-
-      Options FIXED and VALIGN-RIGHT are only available when USE_TABS is
-      enabled."""),
+        (ie: CONTINUATION_INDENT_WIDTH/INDENT_WIDTH tabs or
+        CONTINUATION_INDENT_WIDTH spaces) for continuation alignment.
+      - VALIGN-RIGHT: Vertically align continuation lines to multiple of
+        INDENT_WIDTH columns. Slightly right (one tab or a few spaces) if
+        cannot vertically align continuation lines with indent characters."""),
     CONTINUATION_INDENT_WIDTH=textwrap.dedent("""\
       Indent width used for line continuations."""),
     DEDENT_CLOSING_BRACKETS=textwrap.dedent("""\

--- a/yapftests/format_token_test.py
+++ b/yapftests/format_token_test.py
@@ -26,40 +26,40 @@ class TabbedContinuationAlignPaddingTest(unittest.TestCase):
   def testSpace(self):
     align_style = 'SPACE'
 
-    pad = format_token._TabbedContinuationAlignPadding(0, align_style, 2, 4)
+    pad = format_token._TabbedContinuationAlignPadding(0, align_style, 2)
     self.assertEqual(pad, '')
 
-    pad = format_token._TabbedContinuationAlignPadding(2, align_style, 2, 4)
+    pad = format_token._TabbedContinuationAlignPadding(2, align_style, 2)
     self.assertEqual(pad, ' ' * 2)
 
-    pad = format_token._TabbedContinuationAlignPadding(5, align_style, 2, 4)
+    pad = format_token._TabbedContinuationAlignPadding(5, align_style, 2)
     self.assertEqual(pad, ' ' * 5)
 
   def testFixed(self):
     align_style = 'FIXED'
 
-    pad = format_token._TabbedContinuationAlignPadding(0, align_style, 4, 8)
+    pad = format_token._TabbedContinuationAlignPadding(0, align_style, 4)
     self.assertEqual(pad, '')
 
-    pad = format_token._TabbedContinuationAlignPadding(2, align_style, 4, 8)
-    self.assertEqual(pad, '\t' * 2)
+    pad = format_token._TabbedContinuationAlignPadding(2, align_style, 4)
+    self.assertEqual(pad, '\t')
 
-    pad = format_token._TabbedContinuationAlignPadding(5, align_style, 4, 8)
+    pad = format_token._TabbedContinuationAlignPadding(5, align_style, 4)
     self.assertEqual(pad, '\t' * 2)
 
   def testVAlignRight(self):
     align_style = 'VALIGN-RIGHT'
 
-    pad = format_token._TabbedContinuationAlignPadding(0, align_style, 4, 8)
+    pad = format_token._TabbedContinuationAlignPadding(0, align_style, 4)
     self.assertEqual(pad, '')
 
-    pad = format_token._TabbedContinuationAlignPadding(2, align_style, 4, 8)
+    pad = format_token._TabbedContinuationAlignPadding(2, align_style, 4)
     self.assertEqual(pad, '\t')
 
-    pad = format_token._TabbedContinuationAlignPadding(4, align_style, 4, 8)
+    pad = format_token._TabbedContinuationAlignPadding(4, align_style, 4)
     self.assertEqual(pad, '\t')
 
-    pad = format_token._TabbedContinuationAlignPadding(5, align_style, 4, 8)
+    pad = format_token._TabbedContinuationAlignPadding(5, align_style, 4)
     self.assertEqual(pad, '\t' * 2)
 
 

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -1273,8 +1273,8 @@ def foo_function(arg1, arg2, arg3):
   return ['hello', 'world',]
 """
     expected_formatted_code = """\
-def foo_function(arg1, arg2,
-		arg3):
+def foo_function(
+		arg1, arg2, arg3):
 	return [
 			'hello',
 			'world',
@@ -1312,6 +1312,60 @@ def foo_function(arg1, arg2,
 [style]
 based_on_style = chromium
 USE_TABS = true
+COLUMN_LIMIT=32
+INDENT_WIDTH=4
+CONTINUATION_INDENT_WIDTH=8
+CONTINUATION_ALIGN_STYLE = valign-right
+"""
+    with utils.TempFileContents(self.test_tmpdir, style_contents) as stylepath:
+      self.assertYapfReformats(
+          unformatted_code,
+          expected_formatted_code,
+          extra_options=['--style={0}'.format(stylepath)])
+
+  def testUseSpacesContinuationAlignStyleFixed(self):
+    unformatted_code = """\
+def foo_function(arg1, arg2, arg3):
+  return ['hello', 'world',]
+"""
+    expected_formatted_code = """\
+def foo_function(
+        arg1, arg2, arg3):
+    return [
+            'hello',
+            'world',
+    ]
+"""
+    style_contents = u"""\
+[style]
+based_on_style = chromium
+COLUMN_LIMIT=32
+INDENT_WIDTH=4
+CONTINUATION_INDENT_WIDTH=8
+CONTINUATION_ALIGN_STYLE = fixed
+"""
+    with utils.TempFileContents(self.test_tmpdir, style_contents) as stylepath:
+      self.assertYapfReformats(
+          unformatted_code,
+          expected_formatted_code,
+          extra_options=['--style={0}'.format(stylepath)])
+
+  def testUseSpacesContinuationAlignStyleVAlignRight(self):
+    unformatted_code = """\
+def foo_function(arg1, arg2, arg3):
+  return ['hello', 'world',]
+"""
+    expected_formatted_code = """\
+def foo_function(arg1, arg2,
+                    arg3):
+    return [
+            'hello',
+            'world',
+    ]
+"""
+    style_contents = u"""\
+[style]
+based_on_style = chromium
 COLUMN_LIMIT=32
 INDENT_WIDTH=4
 CONTINUATION_INDENT_WIDTH=8


### PR DESCRIPTION
This PR make `CONTINUATION_ALIGN_STYLE=FIXED` and `CONTINUATION_ALIGN_STYLE=VALIGN-RIGHT` option available for indenting with space.

Ref: #769 

Compare to previous PR (#774) this one should solve the extra line break issue.

--------

Changes made:

* let new line indent generation method in format decision be continuation
  align style aware
* simplify tab replacement in format token as styling logic moved to format decision mostly