### PR TITLE
Adds FORCE_MULTILINE_DICT knob

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,8 @@
   values, not comments, which may be associated with the current line.
 - Don't over-indent a parameter list when not needed. But make sure it is
   properly indented so that it doesn't collide with the lines afterwards.
+- Adds `FORCE_MULTILINE_DICT` knob to ensure dictionaries always split,
+  even when shorter than the max line length.
 
 ## [0.29.0] 2019-11-28
 ### Added

--- a/README.rst
+++ b/README.rst
@@ -473,6 +473,10 @@ Knobs
 ``EACH_DICT_ENTRY_ON_SEPARATE_LINE``
     Place each dictionary entry onto its own line.
 
+``FORCE_MULTILINE_DICT``
+    Respect EACH_DICT_ENTRY_ON_SEPARATE_LINE even if the line is shorter than
+    COLUMN_LIMIT.
+
 ``I18N_COMMENT``
     The regex for an internationalization comment. The presence of this comment
     stops reformatting of that line, because the comments are required to be

--- a/yapf/yapflib/reformatter.py
+++ b/yapf/yapflib/reformatter.py
@@ -257,6 +257,9 @@ def _CanPlaceOnSingleLine(uwline):
   Returns:
     True if the line can or should be added to a single line. False otherwise.
   """
+  token_names = [x.name for x in uwline.tokens]
+  if (style.Get('FORCE_MULTILINE_DICT') and 'LBRACE' in token_names):
+    return False
   indent_amt = style.Get('INDENT_WIDTH') * uwline.depth
   last = uwline.last
   last_index = -1

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -172,6 +172,13 @@ _STYLE_HELP = dict(
       if the list is comma-terminated."""),
     EACH_DICT_ENTRY_ON_SEPARATE_LINE=textwrap.dedent("""\
       Place each dictionary entry onto its own line."""),
+    FORCE_MULTILINE_DICT=textwrap.dedent("""\
+      Require multiline dictionary even if it would normally fit on one line.
+      For example:
+
+        config = {
+            'key1': 'value1'
+        }"""),
     I18N_COMMENT=textwrap.dedent("""\
       The regex for an i18n comment. The presence of this comment stops
       reformatting of that line, because the comments are required to be
@@ -376,6 +383,7 @@ def CreatePEP8Style():
       INDENT_CLOSING_BRACKETS=False,
       DISABLE_ENDING_COMMA_HEURISTIC=False,
       EACH_DICT_ENTRY_ON_SEPARATE_LINE=True,
+      FORCE_MULTILINE_DICT=False,
       I18N_COMMENT='',
       I18N_FUNCTION_CALL='',
       INDENT_DICTIONARY_VALUE=False,
@@ -558,6 +566,7 @@ _STYLE_OPTION_VALUE_CONVERTER = dict(
     INDENT_CLOSING_BRACKETS=_BoolConverter,
     DISABLE_ENDING_COMMA_HEURISTIC=_BoolConverter,
     EACH_DICT_ENTRY_ON_SEPARATE_LINE=_BoolConverter,
+    FORCE_MULTILINE_DICT=_BoolConverter,
     I18N_COMMENT=str,
     I18N_FUNCTION_CALL=_StringListConverter,
     INDENT_DICTIONARY_VALUE=_BoolConverter,

--- a/yapftests/file_resources_test.py
+++ b/yapftests/file_resources_test.py
@@ -438,6 +438,49 @@ class WriteReformattedCodeTest(unittest.TestCase):
           None, s, in_place=False, encoding='utf-8')
     self.assertEqual(stream.getvalue(), s)
 
+class LineEndingTest(unittest.TestCase):
+  def test_line_ending_linefeed(self):
+    lines = [
+      'spam\n',
+      'spam\n'
+    ]
+    actual = file_resources.LineEnding(lines)
+    self.assertEqual(actual, '\n')
+      
+  def test_line_ending_carriage_return(self):
+    lines = [
+      'spam\r',
+      'spam\r'
+    ]
+    actual = file_resources.LineEnding(lines)
+    self.assertEqual(actual, '\r')
+
+  def test_line_ending_combo(self):
+    lines = [
+      'spam\r\n',
+      'spam\r\n'
+    ]
+    actual = file_resources.LineEnding(lines)
+    self.assertEqual(actual, '\r\n')
+
+  def test_line_ending_weighted(self):
+    lines = [
+      'spam\n',
+      'spam\n',
+      'spam\r',
+      'spam\r\n',
+    ]
+    actual = file_resources.LineEnding(lines)
+    self.assertEqual(actual, '\n')
+
+  def test_line_ending_equal_weighted(self):
+    lines = [
+      'spam\n',
+      'spam\r',
+      'spam\r\n',
+    ]
+    actual = file_resources.LineEnding(lines)
+    self.assertEqual(actual, '\r\n')
 
 if __name__ == '__main__':
   unittest.main()

--- a/yapftests/file_resources_test.py
+++ b/yapftests/file_resources_test.py
@@ -438,49 +438,34 @@ class WriteReformattedCodeTest(unittest.TestCase):
           None, s, in_place=False, encoding='utf-8')
     self.assertEqual(stream.getvalue(), s)
 
+
 class LineEndingTest(unittest.TestCase):
+
   def test_line_ending_linefeed(self):
-    lines = [
-      'spam\n',
-      'spam\n'
-    ]
+    lines = ['spam\n', 'spam\n']
     actual = file_resources.LineEnding(lines)
     self.assertEqual(actual, '\n')
-      
+
   def test_line_ending_carriage_return(self):
-    lines = [
-      'spam\r',
-      'spam\r'
-    ]
+    lines = ['spam\r', 'spam\r']
     actual = file_resources.LineEnding(lines)
     self.assertEqual(actual, '\r')
 
   def test_line_ending_combo(self):
-    lines = [
-      'spam\r\n',
-      'spam\r\n'
-    ]
+    lines = ['spam\r\n', 'spam\r\n']
     actual = file_resources.LineEnding(lines)
     self.assertEqual(actual, '\r\n')
 
   def test_line_ending_weighted(self):
     lines = [
-      'spam\n',
-      'spam\n',
-      'spam\r',
-      'spam\r\n',
+        'spam\n',
+        'spam\n',
+        'spam\r',
+        'spam\r\n',
     ]
     actual = file_resources.LineEnding(lines)
     self.assertEqual(actual, '\n')
 
-  def test_line_ending_equal_weighted(self):
-    lines = [
-      'spam\n',
-      'spam\r',
-      'spam\r\n',
-    ]
-    actual = file_resources.LineEnding(lines)
-    self.assertEqual(actual, '\r\n')
 
 if __name__ == '__main__':
   unittest.main()

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -1958,8 +1958,8 @@ class A(object):
 
   def testDontAddBlankLineAfterMultilineString(self):
     code = textwrap.dedent("""\
-      query = '''SELECT id 
-      FROM table 
+      query = '''SELECT id
+      FROM table
       WHERE day in {}'''
       days = ",".join(days)
       """)
@@ -2965,6 +2965,38 @@ class A:
 """
     uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
     self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
+
+  def testForceMultilineDict_True(self):
+    try:
+      style.SetGlobalStyle(
+          style.CreateStyleFromConfig('{force_multiline_dict: true}'))
+      unformatted_code = textwrap.dedent(
+          "responseDict = {'childDict': {'spam': 'eggs'}}\n")
+      uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
+      actual = reformatter.Reformat(uwlines)
+      expected = textwrap.dedent("""\
+        responseDict = {
+            'childDict': {
+                'spam': 'eggs'
+            }
+        }
+      """)
+      self.assertCodeEqual(expected, actual)
+    finally:
+      style.SetGlobalStyle(style.CreateChromiumStyle())
+
+  def testForceMultilineDict_False(self):
+    try:
+      style.SetGlobalStyle(
+          style.CreateStyleFromConfig('{force_multiline_dict: false}'))
+      unformatted_code = textwrap.dedent("""\
+        responseDict = {'childDict': {'spam': 'eggs'}}
+      """)
+      expected_formatted_code = unformatted_code
+      uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
+      self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
+    finally:
+      style.SetGlobalStyle(style.CreateChromiumStyle())
 
 
 if __name__ == '__main__':

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -2982,7 +2982,8 @@ my_dict = {
       """)
       expected_formatted_code = unformatted_code
       uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
-      self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
+      self.assertCodeEqual(expected_formatted_code,
+                           reformatter.Reformat(uwlines))
     finally:
       style.SetGlobalStyle(style.CreateChromiumStyle())
 


### PR DESCRIPTION
I often find myself wanting to format my dictionaries with keys on their own lines, ala:

```
my_dict = {
    'spam': 'eggs',
    'foo': 'bar'
}
```

EACH_DICT_ENTRY_ON_SEPARATE_LINE did previous exist, but would only fire if the length of the dictionary was greater than the max column length. This patch allows it to always be turned on with the FORCE_MULTILINE_DICT config option, even for short dictionaries.

- Defaults to False (off)
- Adds docs
- Adds tests
- While in there, fixed two flaky tests that were dependent on previous tests setting up the environment

NOTE: There may be a better way to do that LBRACE check in reformatter.py. A quick glance through the codebase didn't show anything obvious, but let me know if I'm redoing work here.