### PR TITLE
CHANGELOG: New features to "Added"; MINOR version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,14 @@
 # All notable changes to this project will be documented in this file.
 # This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.29.1] UNRELEASED
+## [0.30.0] UNRELEASED
+### Added
+- Add `FORCE_MULTILINE_DICT` knob to ensure dictionaries always split,
+  even when shorter than the max line length.
+- Add `SPACE_INSIDE_BRACKETS` knob to add spaces inside brackets, braces, and
+  parentheses.
+- Add `SPACES_AROUND_SUBSCRIPT_COLON` knob to add spaces around the subscript /
+  slice operator.
 ### Fixed
 - Honor a disable directive at the end of a multiline comment.
 - Don't require splitting before comments in a list when
@@ -11,12 +18,6 @@
 - Don't over-indent a parameter list when not needed. But make sure it is
   properly indented so that it doesn't collide with the lines afterwards.
 - Don't split between two-word comparison operators: "is not", "not in", etc.
-- Adds `FORCE_MULTILINE_DICT` knob to ensure dictionaries always split,
-  even when shorter than the max line length.
-- New knob `SPACE_INSIDE_BRACKETS` to add spaces inside brackets, braces, and
-  parentheses.
-- New knob `SPACES_AROUND_SUBSCRIPT_COLON` to add spaces around the subscript /
-  slice operator.
 
 ## [0.29.0] 2019-11-28
 ### Added


### PR DESCRIPTION
The FORCE_MULTILINE_DICT, SPACE_INSIDE_BRACKETS,
SPACES_AROUND_SUBSCRIPT_COLON should have been in an Added section
instead of Fixed.

Per Semantic Versioning, this also implies that the next release is now
a new MINOR, 0.30.0 (instead of 0.29.1).