### PR TITLE
Adds walrus test and python 3.7/3.8 tox definitions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36
+envlist=py27,py34,py35,py36,py37,py38
 
 [testenv]
 commands=

--- a/yapf/yapflib/py3compat.py
+++ b/yapf/yapflib/py3compat.py
@@ -20,6 +20,8 @@ import sys
 
 PY3 = sys.version_info[0] >= 3
 PY36 = sys.version_info[0] >= 3 and sys.version_info[1] >= 6
+PY37 = sys.version_info[0] >= 3 and sys.version_info[1] >= 7
+PY38 = sys.version_info[0] >= 3 and sys.version_info[1] >= 8
 
 if PY3:
   StringIO = io.StringIO

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -3033,6 +3033,19 @@ my_dict = {
     finally:
       style.SetGlobalStyle(style.CreateYapfStyle())
 
+  @unittest.skipUnless(py3compat.PY38, 'Requires Python 3.8')
+  def testWalrus(self):
+    unformatted_code = textwrap.dedent("""\
+      if (x  :=  len([1]*1000)>100):
+        print(f'{x} is pretty big' )
+    """)
+    expected = textwrap.dedent("""\
+      if (x := len([1] * 1000) > 100):
+        print(f'{x} is pretty big')
+    """)
+    uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
+    self.assertCodeEqual(expected, reformatter.Reformat(uwlines))
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Give a mouse a cookie...

I was looking at this issue: https://github.com/google/yapf/issues/787
Was curious if lib2to3 supported the walrus operator since the bug was reported (it does: https://bugs.python.org/issue36541#msg365718)

Added a test on the thing, which necessitated adding 3.8 to tox.ini.

Seemed silly to have 3.8 in there but not 3.7, so added that, too.

Also, interestingly enough, the lib2to3 walrus operator support includes 3.7, even though it wasn't introduced until 3.8. I don't think that's a compelling reason to support it in yapf, though.