### PR TITLE
Support custom number of blank lines between top-level imports and variable definitions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,11 @@
 # All notable changes to this project will be documented in this file.
 # This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.31.0] UNRELEASED
+### Added
+- Add 'BLANK_LINES_AFTER_TOP_LEVEL_IMPORTS' to support setting a custom number
+  of blank lines after top-level imports.
+
 ## [0.30.0] 2020-04-23
 ### Added
 - Added `SPACES_AROUND_LIST_DELIMITERS`, `SPACES_AROUND_DICT_DELIMITERS`,

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,8 +4,9 @@
 
 ## [0.31.0] UNRELEASED
 ### Added
-- Add 'BLANK_LINES_AFTER_TOP_LEVEL_IMPORTS' to support setting a custom number
-  of blank lines after top-level imports.
+- Add 'BLANK_LINES_BETWEEN_TOP_LEVEL_IMPORTS_AND_VARIABLES' to support setting
+  a custom number of blank lines between top-level imports and variable
+  definitions.
 
 ## [0.30.0] 2020-04-23
 ### Added

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,3 +14,4 @@ Eli Bendersky <eliben@google.com>
 Sam Clegg <sbc@google.com>
 Łukasz Langa <ambv@fb.com>
 Oleg Butuzov <butuzov@made.ua>
+Mauricio Herrera Cuadra <mauricio@arareko.net>

--- a/README.rst
+++ b/README.rst
@@ -388,6 +388,10 @@ Knobs
 ``BLANK_LINE_BEFORE_CLASS_DOCSTRING``
     Insert a blank line before a class-level docstring.
 
+``BLANK_LINES_AFTER_TOP_LEVEL_IMPORTS``
+    Sets the number of desired blank lines after top-level imports. Useful for
+    compatibility with tools like isort.
+
 ``BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION``
     Sets the number of desired blank lines surrounding top-level function and
     class definitions. For example:
@@ -567,7 +571,7 @@ Knobs
         [1, 2]
 
     will be formatted as:
-    
+
     .. code-block:: python
 
         [ 1, 2 ]
@@ -665,16 +669,16 @@ Knobs
     ``b`` in this code:
 
     .. code-block:: python
-      
+
       abcdef(
           aReallyLongThing: int,
           b: [Int,
               Int])
-   
+
     With the new knob this is split as:
 
     .. code-block:: python
-      
+
       abcdef(
           aReallyLongThing: int,
           b: [Int, Int])

--- a/README.rst
+++ b/README.rst
@@ -388,10 +388,6 @@ Knobs
 ``BLANK_LINE_BEFORE_CLASS_DOCSTRING``
     Insert a blank line before a class-level docstring.
 
-``BLANK_LINES_AFTER_TOP_LEVEL_IMPORTS``
-    Sets the number of desired blank lines after top-level imports. Useful for
-    compatibility with tools like isort.
-
 ``BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION``
     Sets the number of desired blank lines surrounding top-level function and
     class definitions. For example:
@@ -404,6 +400,10 @@ Knobs
                            # <------ is the default setting
         class Bar:
             pass
+
+``BLANK_LINES_BETWEEN_TOP_LEVEL_IMPORTS_AND_VARIABLES``
+    Sets the number of desired blank lines between top-level imports and
+    variable definitions. Useful for compatibility with tools like isort.
 
 ``COALESCE_BRACKETS``
     Do not split consecutive brackets. Only relevant when

--- a/yapf/yapflib/reformatter.py
+++ b/yapf/yapflib/reformatter.py
@@ -653,8 +653,10 @@ def _CalculateNumberOfNewlines(first_token, indent_depth, prev_uwline,
   if first_token.is_name and not indent_depth:
     if (prev_uwline.first.value == 'from' or
         prev_uwline.first.value == 'import'):
-      # Support custom number of blank lines after top-level imports.
-      return 1 + style.Get('BLANK_LINES_AFTER_TOP_LEVEL_IMPORTS')
+      # Support custom number of blank lines between top-level imports and
+      # variable definitions.
+      return 1 + style.Get(
+          'BLANK_LINES_BETWEEN_TOP_LEVEL_IMPORTS_AND_VARIABLES')
 
   prev_last_token = prev_uwline.last
   if prev_last_token.is_docstring:

--- a/yapf/yapflib/reformatter.py
+++ b/yapf/yapflib/reformatter.py
@@ -650,6 +650,12 @@ def _CalculateNumberOfNewlines(first_token, indent_depth, prev_uwline,
     # The docstring shouldn't have a newline before it.
     return NO_BLANK_LINES
 
+  if first_token.is_name and not indent_depth:
+    if (prev_uwline.first.value == 'from' or
+        prev_uwline.first.value == 'import'):
+      # Support custom number of blank lines after top-level imports.
+      return 1 + style.Get('BLANK_LINES_AFTER_TOP_LEVEL_IMPORTS')
+
   prev_last_token = prev_uwline.last
   if prev_last_token.is_docstring:
     if (not indent_depth and first_token.value in {'class', 'def', 'async'}):

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -101,10 +101,11 @@ _STYLE_HELP = dict(
       Insert a blank line before a class-level docstring."""),
     BLANK_LINE_BEFORE_MODULE_DOCSTRING=textwrap.dedent("""\
       Insert a blank line before a module docstring."""),
-    BLANK_LINES_AFTER_TOP_LEVEL_IMPORTS=textwrap.dedent("""\
-      Number of blank lines after top-level imports."""),
     BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION=textwrap.dedent("""\
       Number of blank lines surrounding top-level function and class
+      definitions."""),
+    BLANK_LINES_BETWEEN_TOP_LEVEL_IMPORTS_AND_VARIABLES=textwrap.dedent("""\
+      Number of blank lines between top-level imports and variable
       definitions."""),
     COALESCE_BRACKETS=textwrap.dedent("""\
       Do not split consecutive brackets. Only relevant when
@@ -420,8 +421,8 @@ def CreatePEP8Style():
       BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF=False,
       BLANK_LINE_BEFORE_CLASS_DOCSTRING=False,
       BLANK_LINE_BEFORE_MODULE_DOCSTRING=False,
-      BLANK_LINES_AFTER_TOP_LEVEL_IMPORTS=1,
       BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION=2,
+      BLANK_LINES_BETWEEN_TOP_LEVEL_IMPORTS_AND_VARIABLES=1,
       COALESCE_BRACKETS=False,
       COLUMN_LIMIT=79,
       CONTINUATION_ALIGN_STYLE='SPACE',
@@ -608,8 +609,8 @@ _STYLE_OPTION_VALUE_CONVERTER = dict(
     BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF=_BoolConverter,
     BLANK_LINE_BEFORE_CLASS_DOCSTRING=_BoolConverter,
     BLANK_LINE_BEFORE_MODULE_DOCSTRING=_BoolConverter,
-    BLANK_LINES_AFTER_TOP_LEVEL_IMPORTS=int,
     BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION=int,
+    BLANK_LINES_BETWEEN_TOP_LEVEL_IMPORTS_AND_VARIABLES=int,
     COALESCE_BRACKETS=_BoolConverter,
     COLUMN_LIMIT=int,
     CONTINUATION_ALIGN_STYLE=_ContinuationAlignStyleStringConverter,

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -101,6 +101,8 @@ _STYLE_HELP = dict(
       Insert a blank line before a class-level docstring."""),
     BLANK_LINE_BEFORE_MODULE_DOCSTRING=textwrap.dedent("""\
       Insert a blank line before a module docstring."""),
+    BLANK_LINES_AFTER_TOP_LEVEL_IMPORTS=textwrap.dedent("""\
+      Number of blank lines after top-level imports."""),
     BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION=textwrap.dedent("""\
       Number of blank lines surrounding top-level function and class
       definitions."""),
@@ -418,6 +420,7 @@ def CreatePEP8Style():
       BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF=False,
       BLANK_LINE_BEFORE_CLASS_DOCSTRING=False,
       BLANK_LINE_BEFORE_MODULE_DOCSTRING=False,
+      BLANK_LINES_AFTER_TOP_LEVEL_IMPORTS=1,
       BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION=2,
       COALESCE_BRACKETS=False,
       COLUMN_LIMIT=79,
@@ -605,6 +608,7 @@ _STYLE_OPTION_VALUE_CONVERTER = dict(
     BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF=_BoolConverter,
     BLANK_LINE_BEFORE_CLASS_DOCSTRING=_BoolConverter,
     BLANK_LINE_BEFORE_MODULE_DOCSTRING=_BoolConverter,
+    BLANK_LINES_AFTER_TOP_LEVEL_IMPORTS=int,
     BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION=int,
     COALESCE_BRACKETS=_BoolConverter,
     COLUMN_LIMIT=int,

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -280,7 +280,8 @@ class BasicReformatterTest(yapf_test_helper.YAPFTest):
     try:
       style.SetGlobalStyle(
           style.CreateStyleFromConfig(
-              '{based_on_style: yapf, blank_lines_after_top_level_imports: 2}'))
+              '{based_on_style: yapf, blank_lines_between_top_level_imports_and_variables: 2}'
+          ))
       uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
       self.assertCodeEqual(expected_formatted_code,
                            reformatter.Reformat(uwlines))
@@ -294,6 +295,36 @@ class BasicReformatterTest(yapf_test_helper.YAPFTest):
     expected_formatted_code = textwrap.dedent("""\
         import foo as bar
         # Some comment
+        """)
+    uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
+    self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
+
+    unformatted_code = textwrap.dedent("""\
+        import foo as bar
+        class Baz():
+          pass
+        """)
+    expected_formatted_code = textwrap.dedent("""\
+        import foo as bar
+
+
+        class Baz():
+          pass
+        """)
+    uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
+    self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
+
+    unformatted_code = textwrap.dedent("""\
+        import foo as bar
+        def foobar():
+          pass
+        """)
+    expected_formatted_code = textwrap.dedent("""\
+        import foo as bar
+
+
+        def foobar():
+          pass
         """)
     uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
     self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -253,6 +253,43 @@ class BasicReformatterTest(yapf_test_helper.YAPFTest):
     uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
     self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
 
+  def testBlankLinesAfterTopLevelImport(self):
+    unformatted_code = textwrap.dedent("""\
+        import foo as bar
+        VAR = 'baz'
+        """)
+    expected_formatted_code = textwrap.dedent("""\
+        import foo as bar
+
+        VAR = 'baz'
+        """)
+    uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
+    self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
+
+    unformatted_code = textwrap.dedent("""\
+        import foo as bar
+        # Some comment
+        """)
+    expected_formatted_code = textwrap.dedent("""\
+        import foo as bar
+        # Some comment
+        """)
+    uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
+    self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
+
+    unformatted_code = textwrap.dedent("""\
+        def foobar():
+          from foo import Bar
+          Bar.baz()
+        """)
+    expected_formatted_code = textwrap.dedent("""\
+        def foobar():
+          from foo import Bar
+          Bar.baz()
+        """)
+    uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
+    self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
+
   def testBlankLinesAtEndOfFile(self):
     unformatted_code = textwrap.dedent("""\
         def foobar(): # foo
@@ -421,8 +458,8 @@ class foo(object):\n  \n  def foobar(self):\n    \n    pass\n  \n  def barfoo(se
 
   def testCommentsWithTrailingSpaces(self):
     unformatted_code = textwrap.dedent("""\
-        # Thing 1    
-        # Thing 2    
+        # Thing 1
+        # Thing 2
         """)
     expected_formatted_code = textwrap.dedent("""\
         # Thing 1

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -253,7 +253,7 @@ class BasicReformatterTest(yapf_test_helper.YAPFTest):
     uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
     self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
 
-  def testBlankLinesAfterTopLevelImport(self):
+  def testBlankLinesAfterTopLevelImports(self):
     unformatted_code = textwrap.dedent("""\
         import foo as bar
         VAR = 'baz'
@@ -265,6 +265,27 @@ class BasicReformatterTest(yapf_test_helper.YAPFTest):
         """)
     uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
     self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(uwlines))
+
+    unformatted_code = textwrap.dedent("""\
+        import foo as bar
+
+        VAR = 'baz'
+        """)
+    expected_formatted_code = textwrap.dedent("""\
+        import foo as bar
+
+
+        VAR = 'baz'
+        """)
+    try:
+      style.SetGlobalStyle(
+          style.CreateStyleFromConfig(
+              '{based_on_style: yapf, blank_lines_after_top_level_imports: 2}'))
+      uwlines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
+      self.assertCodeEqual(expected_formatted_code,
+                           reformatter.Reformat(uwlines))
+    finally:
+      style.SetGlobalStyle(style.CreateYapfStyle())
 
     unformatted_code = textwrap.dedent("""\
         import foo as bar


### PR DESCRIPTION
This patch implements support for having a custom number of blank lines (default = 1) between top-level imports and variable definitions.

This feature has been previously requested in issues:
- #340
- #347
- #635 

It is specially useful to enable compatibility with tools like `isort`.