### PR TITLE
Remove dead demo link from readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,8 +37,6 @@ The ultimate goal is that the code YAPF produces is as good as the code that a
 programmer would write if they were following the style guide. It takes away
 some of the drudgery of maintaining your code.
 
-Try out YAPF with this `online demo <https://yapf.now.sh>`_.
-
 .. footer::
 
     YAPF is not an official Google product (experimental or otherwise), it is


### PR DESCRIPTION
Removing: Try out YAPF with this online demo. https://yapf.now.sh/ from readme as the link doesn't work anymore.