### PR TITLE
Add yapf-diff command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -321,6 +321,42 @@ The ``in_place`` argument saves the reformatted code back to the file:
     >>> print(open("foo.py").read())  # contents of file (now fixed)
     a == b
 
+Formatting diffs
+================
+
+Options::
+
+    usage: yapf-diff [-h] [-i] [-p NUM] [--regex PATTERN] [--iregex PATTERN][-v]
+                     [--style STYLE] [--binary BINARY]
+
+    This script reads input from a unified diff and reformats all the changed
+    lines. This is useful to reformat all the lines touched by a specific patch.
+    Example usage for git/svn users:
+
+      git diff -U0 --no-color --relative HEAD^ | yapf-diff -i
+      svn diff --diff-cmd=diff -x-U0 | yapf-diff -p0 -i
+
+    It should be noted that the filename contained in the diff is used
+    unmodified to determine the source file to update. Users calling this script
+    directly should be careful to ensure that the path in the diff is correct
+    relative to the current working directory.
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -i, --in-place        apply edits to files instead of displaying a diff
+      -p NUM, --prefix NUM  strip the smallest prefix containing P slashes
+      --regex PATTERN       custom pattern selecting file paths to reformat
+                            (case sensitive, overrides -iregex)
+      --iregex PATTERN      custom pattern selecting file paths to reformat
+                            (case insensitive, overridden by -regex)
+      -v, --verbose         be more verbose, ineffective without -i
+      --style STYLE         specify formatting style: either a style name (for
+                            example "pep8" or "google"), or the name of a file
+                            with style settings. The default is pep8 unless a
+                            .style.yapf or setup.cfg file located in one of the
+                            parent directories of the source file (or current
+                            directory for stdin)
+      --binary BINARY       location of binary to use for yapf
 
 Knobs
 =====

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ with codecs.open('README.rst', 'r', 'utf-8') as fd:
       entry_points={
           'console_scripts': [
               'yapf = yapf:run_main',
-              'yapf-diff = yapf.yapf_diff:main',
+              'yapf-diff = yapf.third_party.yapf_diff.yapf_diff:main',
           ],
       },
       cmdclass={

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,10 @@ with codecs.open('README.rst', 'r', 'utf-8') as fd:
           'Topic :: Software Development :: Quality Assurance',
       ],
       entry_points={
-          'console_scripts': ['yapf = yapf:run_main'],
+          'console_scripts': [
+              'yapf = yapf:run_main',
+              'yapf-diff = yapf.yapf_diff:main',
+          ],
       },
       cmdclass={
           'test': RunTests,

--- a/yapf/third_party/yapf_diff/LICENSE
+++ b/yapf/third_party/yapf_diff/LICENSE
@@ -1,0 +1,219 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+--- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+

--- a/yapf/third_party/yapf_diff/yapf_diff.py
+++ b/yapf/third_party/yapf_diff/yapf_diff.py
@@ -1,14 +1,16 @@
-#!/usr/bin/env python
+# Modified copy of clang-format-diff.py that works with yapf.
 #
-#===- clang-format-diff.py - ClangFormat Diff Reformatter ----*- python -*--===#
+# Licensed under the Apache License, Version 2.0 (the "License") with LLVM
+# Exceptions; you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Modified to work with yapf instead of clang-format.
+#     https://llvm.org/LICENSE.txt
 #
-# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-# See https://llvm.org/LICENSE.txt for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-#
-#===------------------------------------------------------------------------===#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 This script reads input from a unified diff and reformats all the changed
 lines. This is useful to reformat all the lines touched by a specific patch.

--- a/yapf/yapf_diff.py
+++ b/yapf/yapf_diff.py
@@ -9,7 +9,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 #===------------------------------------------------------------------------===#
-
 """
 This script reads input from a unified diff and reformats all the changed
 lines. This is useful to reformat all the lines touched by a specific patch.
@@ -32,36 +31,53 @@ import subprocess
 import sys
 
 if sys.version_info.major >= 3:
-    from io import StringIO
+  from io import StringIO
 else:
-    from io import BytesIO as StringIO
+  from io import BytesIO as StringIO
 
 
 def main():
-  parser = argparse.ArgumentParser(description=__doc__,
-                                   formatter_class=
-                                           argparse.RawDescriptionHelpFormatter)
-  parser.add_argument('-i', '--in-place', action='store_true', default=False,
-                      help='apply edits to files instead of displaying a diff')
-  parser.add_argument('-p', '--prefix', metavar='NUM', default=1,
-                      help='strip the smallest prefix containing P slashes')
-  parser.add_argument('--regex', metavar='PATTERN', default=None,
-                      help='custom pattern selecting file paths to reformat '
-                      '(case sensitive, overrides -iregex)')
-  parser.add_argument('--iregex', metavar='PATTERN', default=r'.*\.(py)',
-                      help='custom pattern selecting file paths to reformat '
-                      '(case insensitive, overridden by -regex)')
-  parser.add_argument('-v', '--verbose', action='store_true',
-                      help='be more verbose, ineffective without -i')
-  parser.add_argument('--style',
-                      help='specify formatting style: either a style name (for '
-                      'example "pep8" or "google"), or the name of a file with '
-                      'style settings. The default is pep8 unless a '
-                      '.style.yapf or setup.cfg file located in one of the '
-                      'parent directories of the source file (or current '
-                      'directory for stdin)')
-  parser.add_argument('--binary', default='yapf',
-                      help='location of binary to use for yapf')
+  parser = argparse.ArgumentParser(
+      description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+  parser.add_argument(
+      '-i',
+      '--in-place',
+      action='store_true',
+      default=False,
+      help='apply edits to files instead of displaying a diff')
+  parser.add_argument(
+      '-p',
+      '--prefix',
+      metavar='NUM',
+      default=1,
+      help='strip the smallest prefix containing P slashes')
+  parser.add_argument(
+      '--regex',
+      metavar='PATTERN',
+      default=None,
+      help='custom pattern selecting file paths to reformat '
+      '(case sensitive, overrides -iregex)')
+  parser.add_argument(
+      '--iregex',
+      metavar='PATTERN',
+      default=r'.*\.(py)',
+      help='custom pattern selecting file paths to reformat '
+      '(case insensitive, overridden by -regex)')
+  parser.add_argument(
+      '-v',
+      '--verbose',
+      action='store_true',
+      help='be more verbose, ineffective without -i')
+  parser.add_argument(
+      '--style',
+      help='specify formatting style: either a style name (for '
+      'example "pep8" or "google"), or the name of a file with '
+      'style settings. The default is pep8 unless a '
+      '.style.yapf or setup.cfg file located in one of the '
+      'parent directories of the source file (or current '
+      'directory for stdin)')
+  parser.add_argument(
+      '--binary', default='yapf', help='location of binary to use for yapf')
   args = parser.parse_args()
 
   # Extract changed lines for each file.
@@ -103,11 +119,12 @@ def main():
     command.extend(lines)
     if args.style:
       command.extend(['--style', args.style])
-    p = subprocess.Popen(command,
-                         stdout=subprocess.PIPE,
-                         stderr=None,
-                         stdin=subprocess.PIPE,
-                         universal_newlines=True)
+    p = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=None,
+        stdin=subprocess.PIPE,
+        universal_newlines=True)
     stdout, stderr = p.communicate()
     if p.returncode != 0:
       sys.exit(p.returncode)
@@ -116,12 +133,12 @@ def main():
       with open(filename) as f:
         code = f.readlines()
       formatted_code = StringIO(stdout).readlines()
-      diff = difflib.unified_diff(code, formatted_code,
-                                  filename, filename,
+      diff = difflib.unified_diff(code, formatted_code, filename, filename,
                                   '(before formatting)', '(after formatting)')
       diff_string = ''.join(diff)
       if len(diff_string) > 0:
         sys.stdout.write(diff_string)
+
 
 if __name__ == '__main__':
   main()

--- a/yapf/yapf_diff.py
+++ b/yapf/yapf_diff.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+#
+#===- clang-format-diff.py - ClangFormat Diff Reformatter ----*- python -*--===#
+#
+# Modified to work with yapf instead of clang-format.
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===------------------------------------------------------------------------===#
+
+"""
+This script reads input from a unified diff and reformats all the changed
+lines. This is useful to reformat all the lines touched by a specific patch.
+Example usage for git/svn users:
+
+  git diff -U0 --no-color --relative HEAD^ | yapf-diff -i
+  svn diff --diff-cmd=diff -x-U0 | yapf-diff -p0 -i
+
+It should be noted that the filename contained in the diff is used unmodified
+to determine the source file to update. Users calling this script directly
+should be careful to ensure that the path in the diff is correct relative to the
+current working directory.
+"""
+from __future__ import absolute_import, division, print_function
+
+import argparse
+import difflib
+import re
+import subprocess
+import sys
+
+if sys.version_info.major >= 3:
+    from io import StringIO
+else:
+    from io import BytesIO as StringIO
+
+
+def main():
+  parser = argparse.ArgumentParser(description=__doc__,
+                                   formatter_class=
+                                           argparse.RawDescriptionHelpFormatter)
+  parser.add_argument('-i', '--in-place', action='store_true', default=False,
+                      help='apply edits to files instead of displaying a diff')
+  parser.add_argument('-p', '--prefix', metavar='NUM', default=1,
+                      help='strip the smallest prefix containing P slashes')
+  parser.add_argument('--regex', metavar='PATTERN', default=None,
+                      help='custom pattern selecting file paths to reformat '
+                      '(case sensitive, overrides -iregex)')
+  parser.add_argument('--iregex', metavar='PATTERN', default=r'.*\.(py)',
+                      help='custom pattern selecting file paths to reformat '
+                      '(case insensitive, overridden by -regex)')
+  parser.add_argument('-v', '--verbose', action='store_true',
+                      help='be more verbose, ineffective without -i')
+  parser.add_argument('--style',
+                      help='specify formatting style: either a style name (for '
+                      'example "pep8" or "google"), or the name of a file with '
+                      'style settings. The default is pep8 unless a '
+                      '.style.yapf or setup.cfg file located in one of the '
+                      'parent directories of the source file (or current '
+                      'directory for stdin)')
+  parser.add_argument('--binary', default='yapf',
+                      help='location of binary to use for yapf')
+  args = parser.parse_args()
+
+  # Extract changed lines for each file.
+  filename = None
+  lines_by_file = {}
+  for line in sys.stdin:
+    match = re.search(r'^\+\+\+\ (.*?/){%s}(\S*)' % args.prefix, line)
+    if match:
+      filename = match.group(2)
+    if filename is None:
+      continue
+
+    if args.regex is not None:
+      if not re.match('^%s$' % args.regex, filename):
+        continue
+    else:
+      if not re.match('^%s$' % args.iregex, filename, re.IGNORECASE):
+        continue
+
+    match = re.search(r'^@@.*\+(\d+)(,(\d+))?', line)
+    if match:
+      start_line = int(match.group(1))
+      line_count = 1
+      if match.group(3):
+        line_count = int(match.group(3))
+      if line_count == 0:
+        continue
+      end_line = start_line + line_count - 1
+      lines_by_file.setdefault(filename, []).extend(
+          ['--lines', str(start_line) + '-' + str(end_line)])
+
+  # Reformat files containing changes in place.
+  for filename, lines in lines_by_file.items():
+    if args.in_place and args.verbose:
+      print('Formatting {}'.format(filename))
+    command = [args.binary, filename]
+    if args.in_place:
+      command.append('-i')
+    command.extend(lines)
+    if args.style:
+      command.extend(['--style', args.style])
+    p = subprocess.Popen(command,
+                         stdout=subprocess.PIPE,
+                         stderr=None,
+                         stdin=subprocess.PIPE,
+                         universal_newlines=True)
+    stdout, stderr = p.communicate()
+    if p.returncode != 0:
+      sys.exit(p.returncode)
+
+    if not args.in_place:
+      with open(filename) as f:
+        code = f.readlines()
+      formatted_code = StringIO(stdout).readlines()
+      diff = difflib.unified_diff(code, formatted_code,
+                                  filename, filename,
+                                  '(before formatting)', '(after formatting)')
+      diff_string = ''.join(diff)
+      if len(diff_string) > 0:
+        sys.stdout.write(diff_string)
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
This could be a way to add a `yapf-diff` command. I took the latest copy of [clang-format-diff.py](https://github.com/llvm/llvm-project/blob/master/clang/tools/clang-format/clang-format-diff.py), took the required changes from this gist https://github.com/google/yapf/issues/190#issuecomment-285295786, tried to align the command line arguments with the `yapf` arguments and formatted the result with yapf 0.30.0.

Does this look reasonable, or would you like a more integrated argument in the existing `yapf` command?

I would be happy to add some unit tests if this looks like something that could be merged.

Closes #190