### PR TITLE
pre-commit config

### DIFF
--- a/.pre-commit-config.yml
+++ b/.pre-commit-config.yml
@@ -1,0 +1,30 @@
+# File introduces automated checks triggered on git events
+# to enable run `pip install pre-commit && pre-commit install`
+
+repos:
+  - repo: local
+    hooks:
+      - id: yapf
+        name: yapf
+        language: python
+        entry: yapf
+        args: [-i, -vv]
+        types: [python]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: trailing-whitespace
+      - id: check-docstring-first
+      - id: check-json
+      - id: check-added-large-files
+      - id: check-yaml
+      - id: debug-statements
+      - id: requirements-txt-fixer
+      - id: check-merge-conflict
+      - id: double-quote-string-fixer
+      - id: end-of-file-fixer
+      - id: sort-simple-yaml
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes

--- a/.pre-commit-hooks.yml
+++ b/.pre-commit-hooks.yml
@@ -1,0 +1,9 @@
+# File configures YAPF to be used as a git hook with https://github.com/pre-commit/pre-commit
+
+- id: yapf
+  name: yapf
+  description: "A formatter for Python files."
+  entry: yapf
+  args: [-i] #inplace
+  language: python
+  types: [python]


### PR DESCRIPTION
Support for [pre-commit](https://github.com/pre-commit/pre-commit) package.

Introduces automated checks triggered on git events on a local machine,
to enable run `pip install pre-commit && pre-commit install`.