### PR TITLE
Fix directory exclusion on Windows.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@
 - Add 'BLANK_LINES_BETWEEN_TOP_LEVEL_IMPORTS_AND_VARIABLES' to support setting
   a custom number of blank lines between top-level imports and variable
   definitions.
+### Fixed
+- Exclude directories on Windows.
 
 ## [0.30.0] 2020-04-23
 ### Added

--- a/yapf/yapflib/file_resources.py
+++ b/yapf/yapflib/file_resources.py
@@ -154,6 +154,7 @@ def _FindPythonFiles(filenames, recursive, exclude):
   """Find all Python files."""
   if exclude and any(e.startswith('./') for e in exclude):
     raise errors.YapfError("path in '--exclude' should not start with ./")
+  exclude = exclude and [e.rstrip("/" + os.path.sep) for e in exclude]
 
   python_files = []
   for filename in filenames:

--- a/yapf/yapflib/file_resources.py
+++ b/yapf/yapflib/file_resources.py
@@ -187,10 +187,10 @@ def _FindPythonFiles(filenames, recursive, exclude):
 
 def IsIgnored(path, exclude):
   """Return True if filename matches any patterns in exclude."""
-  path = path.lstrip('/')
-  while path.startswith('./'):
+  path = path.lstrip(os.path.sep)
+  while path.startswith('.' + os.path.sep):
     path = path[2:]
-  return any(fnmatch.fnmatch(path, e.rstrip('/')) for e in exclude)
+  return any(fnmatch.fnmatch(path, e.rstrip(os.path.sep)) for e in exclude)
 
 
 def IsPythonFile(filename):

--- a/yapftests/file_resources_test.py
+++ b/yapftests/file_resources_test.py
@@ -152,8 +152,8 @@ class GetCommandLineFilesTest(unittest.TestCase):
     self.old_dir = os.getcwd()
 
   def tearDown(self):  # pylint: disable=g-missing-super-call
-    shutil.rmtree(self.test_tmpdir)
     os.chdir(self.old_dir)
+    shutil.rmtree(self.test_tmpdir)
 
   def _make_test_dir(self, name):
     fullpath = os.path.normpath(os.path.join(self.test_tmpdir, name))

--- a/yapftests/file_resources_test.py
+++ b/yapftests/file_resources_test.py
@@ -313,7 +313,8 @@ class GetCommandLineFilesTest(unittest.TestCase):
                                                'test2/testinner/',
                                            ]))
 
-    self.assertEqual(found, ['test3/foo/bar/bas/xxx/testfile3.py'])
+    self.assertEqual(
+        found, ['test3/foo/bar/bas/xxx/testfile3.py'.replace("/", os.path.sep)])
 
     found = sorted(
         file_resources.GetCommandLineFiles(['.'],
@@ -323,7 +324,8 @@ class GetCommandLineFilesTest(unittest.TestCase):
                                                'test3',
                                            ]))
 
-    self.assertEqual(found, ['./test2/testinner/testfile2.py'])
+    self.assertEqual(
+        found, ['./test2/testinner/testfile2.py'.replace("/", os.path.sep)])
 
   def test_find_with_excluded_current_dir(self):
     with self.assertRaises(errors.YapfError):
@@ -386,7 +388,7 @@ class IsIgnoredTest(unittest.TestCase):
 
   def test_trailing_slash(self):
     self.assertTrue(file_resources.IsIgnored('z', ['z']))
-    self.assertTrue(file_resources.IsIgnored('z', ['z/']))
+    self.assertTrue(file_resources.IsIgnored('z', ['z' + os.path.sep]))
 
 
 class BufferedByteStream(object):


### PR DESCRIPTION
Following on from #880, swap some hard-coded `/`s for `os.path.sep` so that `--exclude folder` works on Windows. 

The 3rd commit is the main change. The 1st is just to get the corresponding `TestCase` to run on Windows. I'm slightly confused as to why the 2nd is needed on Windows but not Linux.

Closes #880.