### PR TITLE
Ignore end of line `# copybara:` directives.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 - Add 'BLANK_LINES_BETWEEN_TOP_LEVEL_IMPORTS_AND_VARIABLES' to support setting
   a custom number of blank lines between top-level imports and variable
   definitions.
+- Ignore end of line `# copybara:` directives when checking line length.
 ### Fixed
 - Exclude directories on Windows.
 

--- a/yapf/yapflib/format_decision_state.py
+++ b/yapf/yapflib/format_decision_state.py
@@ -741,8 +741,8 @@ class FormatDecisionState(object):
 
     # Calculate the penalty for overflowing the column limit.
     penalty = 0
-    if (not current.is_pylint_comment and not current.is_pytype_comment and
-        self.column > self.column_limit):
+    if (not current.is_pylint_comment and not current.is_pytype_comment
+        and not current.is_copybara_comment and self.column > self.column_limit):
       excess_characters = self.column - self.column_limit
       penalty += style.Get('SPLIT_PENALTY_EXCESS_CHARACTER') * excess_characters
 

--- a/yapf/yapflib/format_token.py
+++ b/yapf/yapflib/format_token.py
@@ -378,3 +378,8 @@ class FormatToken(object):
   def is_pytype_comment(self):
     return self.is_comment and re.match(r'#.*\bpytype:\s*(disable|enable)=',
                                         self.value)
+
+  @property
+  def is_copybara_comment(self):
+    return self.is_comment and re.match(r'#.*\bcopybara:(strip|insert|replace)',
+                                        self.value)

--- a/yapf/yapflib/reformatter.py
+++ b/yapf/yapflib/reformatter.py
@@ -259,7 +259,8 @@ def _CanPlaceOnSingleLine(uwline):
   indent_amt = style.Get('INDENT_WIDTH') * uwline.depth
   last = uwline.last
   last_index = -1
-  if last.is_pylint_comment or last.is_pytype_comment:
+  if (last.is_pylint_comment or last.is_pytype_comment
+      or last.is_copybara_comment):
     last = last.previous_token
     last_index = -2
   if last is None:

--- a/yapftests/reformatter_buganizer_test.py
+++ b/yapftests/reformatter_buganizer_test.py
@@ -166,7 +166,10 @@ class _():
   def _():
     X = (
         _ares_label_prefix +
-        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')  # pylint: disable=line-too-long
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'  # pylint: disable=line-too-long
+        'PyTypePyTypePyTypePyTypePyTypePyTypePyTypePyTypePyTypePyTypePyTypePyTypePyType'  # pytype: disable=attribute-error
+        'CopybaraCopybaraCopybaraCopybaraCopybaraCopybaraCopybaraCopybaraCopybara'  # copybara:strip
+    )
 """
     uwlines = yapf_test_helper.ParseAndUnwrap(code)
     self.assertCodeEqual(code, reformatter.Reformat(uwlines))


### PR DESCRIPTION
pylint and pytype end of line comments adjusting their behavior are
already handled specially.  This does the same for copybara.

I don't like that this is turning into a chain of property calls,
refactoring this into a single question of "is this end of line comment
special" would be better if we gain any more of these.

A usual internal comment this will ignore is `# copybara:strip` placed
on a long import line for something being excluded by copybara when
pushing internally maintained code to upstream to keep internal
google-isms from escaping.