### PR TITLE
pyproject.toml support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,8 @@
   a custom number of blank lines between top-level imports and variable
   definitions.
 - Ignore end of line `# copybara:` directives when checking line length.
+- Look at the 'pyproject.toml' file to see if it contains style information for
+  YAPF.
 ### Fixed
 - Exclude directories on Windows.
 

--- a/README.rst
+++ b/README.rst
@@ -113,10 +113,10 @@ Options::
       --style STYLE         specify formatting style: either a style name (for
                             example "pep8" or "google"), or the name of a file
                             with style settings. The default is pep8 unless a
-                            .style.yapf or setup.cfg file located in the same
-                            directory as the source or one of its parent
-                            directories (for stdin, the current directory is
-                            used).
+                            .style.yapf or setup.cfg or pyproject.toml file
+                            located in the same directory as the source or one of
+                            its parent directories (for stdin, the current
+                            directory is used).
       --style-help          show style settings and exit; this output can be saved
                             to .style.yapf to make your settings permanent
       --no-local-style      don't search for local style definition
@@ -198,7 +198,9 @@ YAPF will search for the formatting style in the following manner:
    directory or one of its parent directories.
 3. In the ``[yapf]`` section of a ``setup.cfg`` file in either the current
    directory or one of its parent directories.
-4. In the ``[style]`` section of a ``~/.config/yapf/style`` file in your home
+4. In the ``[tool.yapf]`` section of a ``pyproject.toml`` file in either the current
+   directory or one of its parent directories.
+5. In the ``[style]`` section of a ``~/.config/yapf/style`` file in your home
    directory.
 
 If none of those files are found, the default style is used (PEP8).
@@ -351,9 +353,10 @@ Options::
       --style STYLE         specify formatting style: either a style name (for
                             example "pep8" or "google"), or the name of a file
                             with style settings. The default is pep8 unless a
-                            .style.yapf or setup.cfg file located in one of the
-                            parent directories of the source file (or current
-                            directory for stdin)
+                            .style.yapf or setup.cfg or pyproject.toml file
+                            located in the same directory as the source or one of
+                            its parent directories (for stdin, the current
+                            directory is used).
       --binary BINARY       location of binary to use for yapf
 
 Knobs

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,2 @@
 [bdist_wheel]
 universal = 1
-
-[options]
-install_requires =
-  toml

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [bdist_wheel]
 universal = 1
+
+[options]
+install_requires =
+  toml

--- a/yapf/__init__.py
+++ b/yapf/__init__.py
@@ -325,10 +325,10 @@ def _BuildParser():
       action='store',
       help=('specify formatting style: either a style name (for example "pep8" '
             'or "google"), or the name of a file with style settings. The '
-            'default is pep8 unless a %s or %s file located in the same '
+            'default is pep8 unless a %s or %s or %s file located in the same '
             'directory as the source or one of its parent directories '
             '(for stdin, the current directory is used).' %
-            (style.LOCAL_STYLE, style.SETUP_CONFIG)))
+            (style.LOCAL_STYLE, style.SETUP_CONFIG, style.PYPROJECT_TOML)))
   parser.add_argument(
       '--style-help',
       action='store_true',

--- a/yapf/yapflib/file_resources.py
+++ b/yapf/yapflib/file_resources.py
@@ -21,7 +21,6 @@ import fnmatch
 import os
 import re
 
-import toml
 from lib2to3.pgen2 import tokenize
 
 from yapf.yapflib import errors
@@ -106,6 +105,8 @@ def GetDefaultStyleForDir(dirname, default_style=style.DEFAULT_STYLE):
       pass  # It's okay if it's not there.
     else:
       with fd:
+        import toml
+
         pyproject_toml = toml.load(config_file)
         style_dict = pyproject_toml.get('tool', {}).get('yapf', None)
         if style_dict is not None:

--- a/yapf/yapflib/file_resources.py
+++ b/yapf/yapflib/file_resources.py
@@ -105,12 +105,17 @@ def GetDefaultStyleForDir(dirname, default_style=style.DEFAULT_STYLE):
       pass  # It's okay if it's not there.
     else:
       with fd:
-        import toml
+        try:
+          import toml
+        except ImportError:
+          raise errors.YapfError(
+              "toml package is needed for using pyproject.toml as a configuration file"
+          )
 
         pyproject_toml = toml.load(config_file)
         style_dict = pyproject_toml.get('tool', {}).get('yapf', None)
         if style_dict is not None:
-            return config_file
+          return config_file
 
     if (not dirname or not os.path.basename(dirname) or
         dirname == os.path.abspath(os.path.sep)):

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -751,23 +751,24 @@ def _CreateConfigParserFromConfigFile(config_filename):
       for k, v in style_dict.items():
         config.set('style', k, str(v))
       return config
-    else:
-      config.read_file(style_file)
-      if config_filename.endswith(SETUP_CONFIG):
-        if not config.has_section('yapf'):
-          raise StyleConfigError(
-              'Unable to find section [yapf] in {0}'.format(config_filename))
-        return config
-      elif config_filename.endswith(LOCAL_STYLE):
-        if not config.has_section('style'):
-          raise StyleConfigError(
-              'Unable to find section [style] in {0}'.format(config_filename))
-        return config
-      else:
-        if not config.has_section('style'):
-          raise StyleConfigError(
-              'Unable to find section [style] in {0}'.format(config_filename))
-        return config
+
+    config.read_file(style_file)
+    if config_filename.endswith(SETUP_CONFIG):
+      if not config.has_section('yapf'):
+        raise StyleConfigError(
+            'Unable to find section [yapf] in {0}'.format(config_filename))
+      return config
+
+    if config_filename.endswith(LOCAL_STYLE):
+      if not config.has_section('style'):
+        raise StyleConfigError(
+            'Unable to find section [style] in {0}'.format(config_filename))
+      return config
+
+    if not config.has_section('style'):
+      raise StyleConfigError(
+          'Unable to find section [style] in {0}'.format(config_filename))
+    return config
 
 
 def _CreateStyleFromConfigParser(config):

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -17,8 +17,6 @@ import os
 import re
 import textwrap
 
-import toml
-
 from yapf.yapflib import errors
 from yapf.yapflib import py3compat
 
@@ -745,6 +743,8 @@ def _CreateConfigParserFromConfigFile(config_filename):
   with open(config_filename) as style_file:
     config = py3compat.ConfigParser()
     if config_filename.endswith(PYPROJECT_TOML):
+      import toml
+
       pyproject_toml = toml.load(style_file)
       style_dict = pyproject_toml.get("tool", {}).get("yapf", None)
       if style_dict is None:

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -743,7 +743,12 @@ def _CreateConfigParserFromConfigFile(config_filename):
   with open(config_filename) as style_file:
     config = py3compat.ConfigParser()
     if config_filename.endswith(PYPROJECT_TOML):
-      import toml
+      try:
+        import toml
+      except ImportError:
+        raise errors.YapfError(
+            "toml package is needed for using pyproject.toml as a configuration file"
+        )
 
       pyproject_toml = toml.load(style_file)
       style_dict = pyproject_toml.get("tool", {}).get("yapf", None)

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -746,7 +746,10 @@ def _CreateConfigParserFromConfigFile(config_filename):
     config = py3compat.ConfigParser()
     if config_filename.endswith(PYPROJECT_TOML):
       pyproject_toml = toml.load(style_file)
-      style_dict = pyproject_toml.get("tool", {}).get("yapf", {})
+      style_dict = pyproject_toml.get("tool", {}).get("yapf", None)
+      if style_dict is None:
+        raise StyleConfigError(
+            'Unable to find section [tool.yapf] in {0}'.format(config_filename))
       config.add_section('style')
       for k, v in style_dict.items():
         config.set('style', k, str(v))

--- a/yapftests/file_resources_test.py
+++ b/yapftests/file_resources_test.py
@@ -119,17 +119,17 @@ class GetDefaultStyleForDirTest(unittest.TestCase):
 
   def test_pyproject_toml(self):
     # An empty pyproject.toml file should not be used
-    setup_config = os.path.join(self.test_tmpdir, 'pyproject.toml')
-    open(setup_config, 'w').close()
+    pyproject_toml = os.path.join(self.test_tmpdir, 'pyproject.toml')
+    open(pyproject_toml, 'w').close()
 
     test_dir = os.path.join(self.test_tmpdir, 'dir1')
     style_name = file_resources.GetDefaultStyleForDir(test_dir)
     self.assertEqual(style_name, 'pep8')
 
     # One with a '[tool.yapf]' section should be used
-    with open(setup_config, 'w') as f:
+    with open(pyproject_toml, 'w') as f:
       f.write('[tool.yapf]\n')
-    self.assertEqual(setup_config,
+    self.assertEqual(pyproject_toml,
                      file_resources.GetDefaultStyleForDir(test_dir))
 
   def test_local_style_at_root(self):

--- a/yapftests/file_resources_test.py
+++ b/yapftests/file_resources_test.py
@@ -117,6 +117,21 @@ class GetDefaultStyleForDirTest(unittest.TestCase):
     self.assertEqual(setup_config,
                      file_resources.GetDefaultStyleForDir(test_dir))
 
+  def test_pyproject_toml(self):
+    # An empty pyproject.toml file should not be used
+    setup_config = os.path.join(self.test_tmpdir, 'pyproject.toml')
+    open(setup_config, 'w').close()
+
+    test_dir = os.path.join(self.test_tmpdir, 'dir1')
+    style_name = file_resources.GetDefaultStyleForDir(test_dir)
+    self.assertEqual(style_name, 'pep8')
+
+    # One with a '[tool.yapf]' section should be used
+    with open(setup_config, 'w') as f:
+      f.write('[tool.yapf]\n')
+    self.assertEqual(setup_config,
+                     file_resources.GetDefaultStyleForDir(test_dir))
+
   def test_local_style_at_root(self):
     # Test behavior of files located on the root, and under root.
     rootdir = os.path.abspath(os.path.sep)

--- a/yapftests/style_test.py
+++ b/yapftests/style_test.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Tests for yapf.style."""
 
+import os
 import shutil
 import tempfile
 import textwrap
@@ -225,6 +226,26 @@ class StyleFromFileTest(unittest.TestCase):
       with self.assertRaisesRegexp(style.StyleConfigError,
                                    'Unknown style option'):
         style.CreateStyleFromConfig(filepath)
+
+  def testPyprojectTomlNoStyleSection(self):
+    filepath = os.path.join(self.test_tmpdir, 'pyproject.toml')
+    _ = open(filepath, 'w')
+    with self.assertRaisesRegexp(style.StyleConfigError,
+                                 'Unable to find section'):
+      style.CreateStyleFromConfig(filepath)
+
+  def testPyprojectTomlParseStyleSection(self):
+    cfg = textwrap.dedent(u'''\
+        [tool.yapf]
+        based_on_style = "pep8"
+        continuation_indent_width = 40
+        ''')
+    filepath = os.path.join(self.test_tmpdir, 'pyproject.toml')
+    with open(filepath, 'w') as f:
+        f.write(cfg)
+    cfg = style.CreateStyleFromConfig(filepath)
+    self.assertTrue(_LooksLikePEP8Style(cfg))
+    self.assertEqual(cfg['CONTINUATION_INDENT_WIDTH'], 40)
 
 
 class StyleFromDict(unittest.TestCase):

--- a/yapftests/style_test.py
+++ b/yapftests/style_test.py
@@ -227,14 +227,14 @@ class StyleFromFileTest(unittest.TestCase):
                                    'Unknown style option'):
         style.CreateStyleFromConfig(filepath)
 
-  def testPyprojectTomlNoStyleSection(self):
+  def testPyprojectTomlNoYapfSection(self):
     filepath = os.path.join(self.test_tmpdir, 'pyproject.toml')
     _ = open(filepath, 'w')
     with self.assertRaisesRegexp(style.StyleConfigError,
                                  'Unable to find section'):
       style.CreateStyleFromConfig(filepath)
 
-  def testPyprojectTomlParseStyleSection(self):
+  def testPyprojectTomlParseYapfSection(self):
     cfg = textwrap.dedent(u'''\
         [tool.yapf]
         based_on_style = "pep8"


### PR DESCRIPTION
This PR is for #708

I added `pyproject.toml` support.
Section syntax of `pyproject.toml` file is the same as @samypr100 's explanation in #708.

Please let me know if I miss anything.
Thank you.