### PR TITLE
Elaborate on based_on_style origins and use cases.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -176,10 +176,18 @@ with a ``[yapf]`` heading. For example:
 
 The ``based_on_style`` setting determines which of the predefined styles this
 custom style is based on (think of it like subclassing). Four
-styles are predefined: ``pep8`` (default), ``google``, ``yapf``, and ``facebook``
-(see ``_STYLE_NAME_TO_FACTORY`` in style.py_).
+styles are predefined:
 
-.. _style.py: https://github.com/google/yapf/blob/main/yapf/yapflib/style.py#L445
+- ``pep8`` (default)
+- ``google`` (based off of the `Google Python Style Guide`_)
+- ``yapf`` (for use with Google open source projects)
+- ``facebook``
+
+.. _`Google Python Style Guide`: https://github.com/google/styleguide/blob/gh-pages/pyguide.md
+
+See ``_STYLE_NAME_TO_FACTORY`` in style.py_ for details.
+
+.. _style.py: https://github.com/google/yapf/blob/main/yapf/yapflib/style.py
 
 It's also possible to do the same on the command line with a dictionary. For
 example:


### PR DESCRIPTION
Several Google OSS projects I have contributed to have mistakenly assumed that they should use the `"google"` style with `indent_width` manually set to `2`. Since Google does not follow the (public) Google Python Style Guide however, this creates numerous diffs between the internal formatter and `yapf --style=google`.

`yapf --style=yapf` does not perfectly match the internal formatter (e.g. for docstrings), but it is much closer than `yapf --style={based_on_style: google, indent_width: 2}`, particularly since it sets `SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN = True`.

(I also removed the line reference from the `_style.py` link as it was very out of date, and difficult to maintain).