### PR TITLE
Fix yapf-diff install by automatically finding valid packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import codecs
 import sys
 import unittest
 
-from setuptools import setup, Command
+from setuptools import find_packages, setup, Command
 
 import yapf
 
@@ -49,7 +49,7 @@ with codecs.open('README.rst', 'r', 'utf-8') as fd:
       author='Google Inc.',
       maintainer='Bill Wendling',
       maintainer_email='morbo@google.com',
-      packages=['yapf', 'yapf.yapflib', 'yapftests'],
+      packages=find_packages('.'),
       classifiers=[
           'Development Status :: 4 - Beta',
           'Environment :: Console',


### PR DESCRIPTION
This PR fixes #920 by having `setup.py` automatically find all python packages within the tree. This avoids a similar issue in the future if other packages are added inside `third_party`. 

Only directories with `__init__.py` files will be treated as packages, so `plugins`, for example, is not searched. For the more conservative, this could be refactored to only recursively search `third_party`, and require explicit lists everywhere else.