### PR TITLE
change ignore config format for pyproject.toml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -156,11 +156,12 @@ If you use ``pyproject.toml``, exclude patterns are specified by ``ignore_patten
 in ``[tool.yapfignore]`` section. For example:
 
 .. code-block:: ini
+
    [tool.yapfignore]
-   ignore_patterns="""
-   temp/**/*.py
-   temp2/*.py
-   """
+   ignore_patterns = [
+     "temp/**/*.py",
+     "temp2/*.py"
+   ]
 
 Formatting style
 ================

--- a/yapf/yapflib/file_resources.py
+++ b/yapf/yapflib/file_resources.py
@@ -57,19 +57,13 @@ def _GetExcludePatternsFromPyprojectToml(filename):
         "toml package is needed for using pyproject.toml as a configuration file"
     )
 
-  pyproject_toml = toml.load(filename)
   if os.path.isfile(filename) and os.access(filename, os.R_OK):
-    excludes = pyproject_toml.get('tool',
-                                  {}).get('yapfignore',
-                                          {}).get('ignore_patterns', None)
-  if excludes is None:
-    return []
-
-  for line in excludes.split('\n'):
-    if line.strip() and not line.startswith('#'):
-      ignore_patterns.append(line.strip())
-  if any(e.startswith('./') for e in ignore_patterns):
-    raise errors.YapfError('path in pyproject.toml should not start with ./')
+    pyproject_toml = toml.load(filename)
+    ignore_patterns = pyproject_toml.get('tool',
+                                         {}).get('yapfignore',
+                                                 {}).get('ignore_patterns', [])
+    if any(e.startswith('./') for e in ignore_patterns):
+      raise errors.YapfError('path in pyproject.toml should not start with ./')
 
   return ignore_patterns
 

--- a/yapftests/file_resources_test.py
+++ b/yapftests/file_resources_test.py
@@ -82,9 +82,9 @@ class GetExcludePatternsForDir(unittest.TestCase):
     ignore_patterns = ['temp/**/*.py', 'temp2/*.py']
     with open(local_ignore_file, 'w') as f:
       f.write('[tool.yapfignore]\n')
-      f.write('ignore_patterns="""')
-      f.writelines('\n'.join(ignore_patterns))
-      f.write('"""')
+      f.write('ignore_patterns=[')
+      f.writelines('\n,'.join([f'"{p}"' for p in ignore_patterns]))
+      f.write(']')
 
     self.assertEqual(
         sorted(file_resources.GetExcludePatternsForDir(self.test_tmpdir)),
@@ -99,9 +99,9 @@ class GetExcludePatternsForDir(unittest.TestCase):
     ignore_patterns = ['temp/**/*.py', './wrong/syntax/*.py']
     with open(local_ignore_file, 'w') as f:
       f.write('[tool.yapfignore]\n')
-      f.write('ignore_patterns="""')
-      f.writelines('\n'.join(ignore_patterns))
-      f.write('"""')
+      f.write('ignore_patterns=[')
+      f.writelines('\n,'.join([f'"{p}"' for p in ignore_patterns]))
+      f.write(']')
 
     with self.assertRaises(errors.YapfError):
       file_resources.GetExcludePatternsForDir(self.test_tmpdir)


### PR DESCRIPTION
fix #904 

Change ignore configuration format to more toml way.

ref:
https://github.com/google/yapf/issues/904#issuecomment-879208657


Thanks @dclong