### PR TITLE
[fixed] double imported module

### DIFF
--- a/yapf/yapflib/py3compat.py
+++ b/yapf/yapflib/py3compat.py
@@ -27,8 +27,6 @@ if PY3:
   StringIO = io.StringIO
   BytesIO = io.BytesIO
 
-  import codecs
-
   def open_with_encoding(filename, mode, encoding, newline=''):  # pylint: disable=unused-argument
     return codecs.open(filename, mode=mode, encoding=encoding)
 


### PR DESCRIPTION
fixing on ```yapf/yapflib/py3compat.py``` which:

- [x] removed unused module of ```codecs``` because it was imported previously ```on line 16``` 