### PR TITLE
Added yapf_api.FormatTree

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@
 ### Added
 - Look at the 'pyproject.toml' file to see if it contains ignore file information
   for YAPF.
+- New entry point `yapf_api.FormatTree`for formatting lib2to3 concrete
+  syntax trees.
 ### Fixed
 - Enable `BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF` knob for "pep8" style, so
   method definitions inside a class are surrounded by a single blank line as

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@
 ### Added
 - Look at the 'pyproject.toml' file to see if it contains ignore file information
   for YAPF.
-- New entry point `yapf_api.FormatTree`for formatting lib2to3 concrete
+- New entry point `yapf_api.FormatTree` for formatting lib2to3 concrete
   syntax trees.
 ### Fixed
 - Enable `BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF` knob for "pep8" style, so


### PR DESCRIPTION
The new entry point allows to avoid re-parsing when a lib2to3 pytree has already been constructed.

Closes #951.