### PR TITLE
Update README.rst for style file format

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,11 +175,11 @@ the predefined styles (e.g., ``pep8`` or ``google``), a path to a configuration
 file that specifies the desired style, or a dictionary of key/value pairs.
 
 The config file is a simple listing of (case-insensitive) ``key = value`` pairs
-with a ``[yapf]`` heading. For example:
+with a ``[style]`` heading. For example:
 
 .. code-block:: ini
 
-    [yapf]
+    [style]
     based_on_style = pep8
     spaces_before_comment = 4
     split_before_logical_operator = true


### PR DESCRIPTION
I'm a brand new user, so this could be wrong. The README says your style file puts style declarations in a `[yapf]` block. That doesn't work for me with yapf 0.31.0 from pip; it looks like it should be a `[style]` block. 

This change updates the README for new users like me copy-pasting. I noted there's still a few occurrences of `[yapf]` in the code. Mostly comments, but also one test. Maybe those should be updated too.