### PR TITLE
``pytree_utils.ParseCodeToTree`` now adds a trailing EOL if needed

### DIFF
--- a/yapf/yapflib/pytree_utils.py
+++ b/yapf/yapflib/pytree_utils.py
@@ -25,6 +25,7 @@ the lib2to3 library.
 """
 
 import ast
+import os
 
 from lib2to3 import pygram
 from lib2to3 import pytree
@@ -108,6 +109,9 @@ def ParseCodeToTree(code):
   """
   # This function is tiny, but the incantation for invoking the parser correctly
   # is sufficiently magical to be worth abstracting away.
+  if not code.endswith(os.linesep):
+    code += os.linesep
+
   try:
     # Try to parse using a Python 3 grammar, which is more permissive (print and
     # exec are not keywords).

--- a/yapf/yapflib/yapf_api.py
+++ b/yapf/yapflib/yapf_api.py
@@ -177,9 +177,6 @@ def FormatCode(unformatted_source,
     Tuple of (reformatted_source, changed). reformatted_source conforms to the
     desired formatting style. changed is True if the source changed.
   """
-  if not unformatted_source.endswith('\n'):
-    unformatted_source += '\n'
-
   try:
     tree = pytree_utils.ParseCodeToTree(unformatted_source)
   except parse.ParseError as e:


### PR DESCRIPTION
This was previously done by ``yapf_api.FormatCode``, but I think it makes
more sense to have it in ``pytree_utils.ParseCodeToTree``, because the
grammar requires a trailing EOL.