### PR TITLE
Split line before all comparison operators

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@
 ### Changes
 - Moved 'pytree' parsing tools into its own subdirectory.
 - Add support for Python 3.10.
+### Fixed
+- Split line before all comparison operators.
 
 ## [0.32.0] 2021-12-26
 ### Added

--- a/yapf/pytree/split_penalty.py
+++ b/yapf/pytree/split_penalty.py
@@ -603,6 +603,9 @@ def _RecAnnotate(tree, annotate_name, annotate_value):
       pytree_utils.SetNodeAnnotation(tree, annotate_name, annotate_value)
 
 
+_COMP_OPS = frozenset({'==', '!=', '<=', '<', '>', '>=', '<>', 'in', 'is'})
+
+
 def _StronglyConnectedCompOp(op):
   if (len(op.children[1].children) == 2 and
       pytree_utils.NodeName(op.children[1]) == 'comp_op'):
@@ -613,7 +616,7 @@ def _StronglyConnectedCompOp(op):
         pytree_utils.LastLeafNode(op.children[1]).value == 'not'):
       return True
   if (isinstance(op.children[1], pytree.Leaf) and
-      op.children[1].value in {'==', 'in'}):
+      op.children[1].value in _COMP_OPS):
     return True
   return False
 

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -1543,6 +1543,31 @@ s = 'foo \\
     llines = yapf_test_helper.ParseAndUnwrap(code)
     self.assertCodeEqual(code, reformatter.Reformat(llines))
 
+  def testNoSplittingAroundCompOperators(self):
+    code = textwrap.dedent("""\
+        c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa is not bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+        c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+        c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa not in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+
+        c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa is bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+        c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa <= bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+        """)
+    expected_code = textwrap.dedent("""\
+        c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+             is not bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+        c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+             in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+        c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+             not in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+
+        c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+             is bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+        c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+             <= bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+        """)
+    llines = yapf_test_helper.ParseAndUnwrap(code)
+    self.assertCodeEqual(expected_code, reformatter.Reformat(llines))
+
   def testNoSplittingWithinSubscriptList(self):
     code = textwrap.dedent("""\
         somequitelongvariablename.somemember[(a, b)] = {


### PR DESCRIPTION
## Justification
Currently, linebreak occurs after the comparison operators, except `is not`, `in`, and `not in`. This PR will make the formatter split lines before the other operators, e.g., `<=`, to comply with the PEP 8.

## Explanation

The results below are the result of this command:
```bash
yapf --no-local --diff test.py
```

And the original content of `test.py` is:

```
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = [1]
bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = [2]

c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa is not bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa not in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)

c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa is bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa <= bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
```

### Old behavior

```diff
--- test.py	(original)
+++ test.py	(reformatted)
@@ -1,9 +1,14 @@
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = [1]
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = [2]

-c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa is not bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
-c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
-c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa not in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+     is not bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+     in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+     not in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)

-c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa is bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
-c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa <= bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa is
+     bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa <=
+     bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
```

### Changed behavior

```diff
--- test.py	(original)
+++ test.py	(reformatted)
@@ -1,9 +1,14 @@
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = [1]
 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = [2]

-c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa is not bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
-c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
-c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa not in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+     is not bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+     in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+     not in bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)

-c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa is bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
-c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa <= bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+     is bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+c = (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+     <= bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
```