### PR TITLE
docs: Fix a few typos

### DIFF
--- a/yapf/yapflib/format_decision_state.py
+++ b/yapf/yapflib/format_decision_state.py
@@ -14,7 +14,7 @@
 """Implements a format decision state object that manages whitespace decisions.
 
 Each token is processed one at a time, at which point its whitespace formatting
-decisions are made. A graph of potential whitespace formattings is created,
+decisions are made. A graph of potential whitespace formatting is created,
 where each node in the graph is a format decision state object. The heuristic
 tries formatting the token with and without a newline before it to determine
 which one has the least penalty. Therefore, the format decision state object for

--- a/yapf/yapflib/logical_line.py
+++ b/yapf/yapflib/logical_line.py
@@ -159,7 +159,7 @@ class LogicalLine(object):
     have spaces around them, for example).
 
     Arguments:
-      indent_per_depth: how much spaces to indend per depth level.
+      indent_per_depth: how much spaces to indent per depth level.
 
     Returns:
       A string representing the line as code.

--- a/yapftests/file_resources_test.py
+++ b/yapftests/file_resources_test.py
@@ -350,7 +350,7 @@ class GetCommandLineFilesTest(unittest.TestCase):
     child of the current directory which has been specified in a relative
     manner.
 
-    At its core, the bug has to do with overzelous stripping of "./foo" so that
+    At its core, the bug has to do with overzealous stripping of "./foo" so that
     it removes too much from "./.foo" .
     """
     tdir1 = self._make_test_dir('.test1')


### PR DESCRIPTION
There are small typos in:
- yapf/yapflib/format_decision_state.py
- yapf/yapflib/logical_line.py
- yapftests/file_resources_test.py

Fixes:
- Should read `overzealous` rather than `overzelous`.
- Should read `indent` rather than `indend`.
- Should read `formatting` rather than `formattings`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md