### PR TITLE
Two fixes for the _AlignTrailingComments(final_lines) function

### DIFF
--- a/yapf/yapflib/reformatter.py
+++ b/yapf/yapflib/reformatter.py
@@ -321,7 +321,7 @@ def _AlignTrailingComments(final_lines):
 
             if line_tok.is_comment:
               pc_line_lengths.append(len(line_content))
-            else:
+            elif not line_tok.is_pseudo:
               line_content += '{}{}'.format(whitespace_prefix, line_tok.value)
 
           if pc_line_lengths:
@@ -361,15 +361,18 @@ def _AlignTrailingComments(final_lines):
                   aligned_col - pc_line_lengths[pc_line_length_index] - 1)
               pc_line_length_index += 1
 
-              line_content = []
+              print('line_tok:', len(line_tok.formatted_whitespace_prefix.lstrip('\n')))
+              print('padded spaces:', len(whitespace))
 
+              line_content = []
+              padded_space = whitespace
               for comment_line_index, comment_line in enumerate(
                   line_tok.value.split('\n')):
-                line_content.append('{}{}'.format(whitespace,
+                line_content.append('{}{}'.format(padded_space,
                                                   comment_line.strip()))
 
                 if comment_line_index == 0:
-                  whitespace = ' ' * (aligned_col - 1)
+                  padded_space = ' ' * (aligned_col - 1)
 
               line_content = '\n'.join(line_content)
 
@@ -378,7 +381,12 @@ def _AlignTrailingComments(final_lines):
               existing_whitespace_prefix = \
                 line_tok.formatted_whitespace_prefix.lstrip('\n')
 
-              if line_content.startswith(existing_whitespace_prefix):
+              # In case that the existing spaces larger than
+              # spaces that needed to pad, set the whitespace_prefix to empty
+              if len(existing_whitespace_prefix)>len(whitespace):
+                    line_tok.whitespace_prefix = ''
+
+              elif line_content.startswith(existing_whitespace_prefix):
                 line_content = line_content[len(existing_whitespace_prefix):]
 
               line_tok.value = line_content


### PR DESCRIPTION
#### Hello all yapf founders!
I want to suggest two fixes for the ***_AlignTrailingComments(final_lines)*** function.


### Two fixes
- When *INDENT_DICTIONARY_VALUE* is set True (default setting for *yapf* and *google* style), there will be pseudo parentheses added around dictionary values in the logical line, and they will be added when calculating the maximum line length before inline comment, but in output lines, the pseudo parentheses are excluded, so the following will happen:
   ```
  func( 1 )                                             # Line 1, the maximum length includes pseudo
  func( 2 )                                             # Line 2, the maximum length includes pseudo
  d = { key1: value1, key2: value2, key3: value3} # Line 3, but the pseudo parentheses are not shown
  func( 3 )                                             # Line 4, the maximum length includes pseudo
  func( 4 )                                             # line 5, the maximum length includes pseudo
  ```
   So when appending to the line content that is before the inline comment, do not include the pseudo   
   parentheses around the dictionary values by changing the condition 

  ```
  else:
	line_content += '{}{}'.format(whitespace_prefix, line_tok.value)
  ```
  into 
  ```
  elif not line_tok.is_pseudo:
	line_content += '{}{}'.format(whitespace_prefix, line_tok.value)
  ```
- Fix the case when the existing space before the inline comment is larger than the padding spaces needed to align.
  Some edge cases (often happens to comments inside an object(e.g. a dictionary) logical line as following) when **_AnalyzeSolutionSpace(state)** is False for the logical line, the function _RetainHorizontalSpacing(lline) is called where *spaces_required_before* as a list is replaced with the actual spaces before the comment token. And if the number of the actual spaces before (aka the existing spaces before) the comment token is larger than the spaces needed to pad for alignment, the comment token will keep being added with the padding spaces and keep moving further towards right each time you run.
  ```
  func( 1 )               # Line 1
  func( 2 )               # Line 2
  d = {                    # line 3 comment 1 where the existing spaces before is 1 space larger than padded spaces
      key1: value1,       # line 3 comment2
      key2: value2,       # line 3 comment3
      key3: value3
  }                       # line 3 comment4

  ```
  The solution is to set the whitespace_prefix of the comment token into empty string when the number of  
  existing spaces are larger:
  ```

  if len(existing_whitespace_prefix)>len(whitespace):
                    line_tok.whitespace_prefix = ''

  ```
<br>