### PR TITLE
Add a new knob and a change for inline comment alignment

### DIFF
--- a/yapf/pytree/comment_splicer.py
+++ b/yapf/pytree/comment_splicer.py
@@ -42,7 +42,6 @@ def SpliceComments(tree):
   # This is a list because Python 2.x doesn't have 'nonlocal' :)
   prev_leaf = [None]
   _AnnotateIndents(tree)
-
   def _VisitNodeRec(node):
     """Recursively visit each node to splice comments into the AST."""
     # This loop may insert into node.children, so we'll iterate over a copy.

--- a/yapf/yapflib/format_decision_state.py
+++ b/yapf/yapflib/format_decision_state.py
@@ -644,6 +644,12 @@ class FormatDecisionState(object):
 
     if not dry_run:
       indent_level = self.line.depth
+      #-----------------------NOTE-----------------------------------
+      # we want newline comments inside the lline to
+      # keep their original indentations
+      if current.is_comment:
+        indent_level = int(current.column/style.Get('INDENT_WIDTH'))
+      #---------------------Added by Xiao----------------------------
       spaces = self.column
       if spaces:
         spaces -= indent_level * style.Get('INDENT_WIDTH')

--- a/yapf/yapflib/format_decision_state.py
+++ b/yapf/yapflib/format_decision_state.py
@@ -644,12 +644,6 @@ class FormatDecisionState(object):
 
     if not dry_run:
       indent_level = self.line.depth
-      #-----------------------NOTE below-----------------------------------
-      # we want newline comments inside the lline to
-      # keep their original indentations
-      if current.is_comment:
-        indent_level = int(current.column/style.Get('INDENT_WIDTH'))
-      #---------------------Added by Xiao----------------------------
       spaces = self.column
       if spaces:
         spaces -= indent_level * style.Get('INDENT_WIDTH')

--- a/yapf/yapflib/format_decision_state.py
+++ b/yapf/yapflib/format_decision_state.py
@@ -644,7 +644,7 @@ class FormatDecisionState(object):
 
     if not dry_run:
       indent_level = self.line.depth
-      #-----------------------NOTE-----------------------------------
+      #-----------------------NOTE below-----------------------------------
       # we want newline comments inside the lline to
       # keep their original indentations
       if current.is_comment:

--- a/yapf/yapflib/reformatter.py
+++ b/yapf/yapflib/reformatter.py
@@ -389,14 +389,14 @@ def _AlignTrailingComments(final_lines):
                 line_content = '{}{}'.format(whitespace, line_tok.value.strip())
               else:
                 line_content = []
-
+                padded_space = whitespace
                 for comment_line_index, comment_line in enumerate(
                     line_tok.value.split('\n')):
-                  line_content.append('{}{}'.format(whitespace,
+                  line_content.append('{}{}'.format(padded_space,
                                                   comment_line.strip()))
 
                   if comment_line_index == 0:
-                    whitespace = ' ' * (aligned_col - 1)
+                    padded_space = ' ' * (aligned_col - 1)
 
                 line_content = '\n'.join(line_content)
 
@@ -407,9 +407,9 @@ def _AlignTrailingComments(final_lines):
               # beginning of the line.
               existing_whitespace_prefix = \
                 line_tok.formatted_whitespace_prefix.lstrip('\n')
-              # in case that the existing spaces larger than spaces that needed to pad
-              if (len(whitespace) == 1 or len(whitespace) > 1 and
-                    len(existing_whitespace_prefix)>len(whitespace)):
+              # in case that the existing spaces larger than
+              # spaces that needed to pad, set the whitespace_prefix to empty
+              if len(existing_whitespace_prefix)>len(whitespace):
                     line_tok.whitespace_prefix = ''
               elif line_content.startswith(existing_whitespace_prefix):
                 line_content = line_content[len(existing_whitespace_prefix):]

--- a/yapf/yapflib/reformatter.py
+++ b/yapf/yapflib/reformatter.py
@@ -333,7 +333,7 @@ def _AlignTrailingComments(final_lines):
             # if comment starts with '\n', it will save length 0
             if line_tok.is_comment:
               pc_line_lengths.append(len(line_content))
-            elif not line_tok.is_pseudo:
+            else:
               line_content += '{}{}'.format(whitespace_prefix, line_tok.value)
 
           if pc_line_lengths:
@@ -389,14 +389,13 @@ def _AlignTrailingComments(final_lines):
                 line_content = '{}{}'.format(whitespace, line_tok.value.strip())
               else:
                 line_content = []
-                padded_space = whitespace
                 for comment_line_index, comment_line in enumerate(
                     line_tok.value.split('\n')):
-                  line_content.append('{}{}'.format(padded_space,
+                  line_content.append('{}{}'.format(whitespace,
                                                   comment_line.strip()))
 
                   if comment_line_index == 0:
-                    padded_space = ' ' * (aligned_col - 1)
+                    whitespace = ' ' * (aligned_col - 1)
 
                 line_content = '\n'.join(line_content)
 
@@ -407,11 +406,8 @@ def _AlignTrailingComments(final_lines):
               # beginning of the line.
               existing_whitespace_prefix = \
                 line_tok.formatted_whitespace_prefix.lstrip('\n')
-              # in case that the existing spaces larger than
-              # spaces that needed to pad, set the whitespace_prefix to empty
-              if len(existing_whitespace_prefix)>len(whitespace):
-                    line_tok.whitespace_prefix = ''
-              elif line_content.startswith(existing_whitespace_prefix):
+
+              if line_content.startswith(existing_whitespace_prefix):
                 line_content = line_content[len(existing_whitespace_prefix):]
 
               line_tok.value = line_content

--- a/yapf/yapflib/reformatter.py
+++ b/yapf/yapflib/reformatter.py
@@ -22,6 +22,7 @@ can be merged together are. The best formatting is returned as a string.
 from __future__ import unicode_literals
 
 import collections
+from distutils.errors import LinkError
 import heapq
 import re
 
@@ -277,7 +278,7 @@ def _AlignTrailingComments(final_lines):
     for tok in line.tokens:
       if (tok.is_comment and isinstance(tok.spaces_required_before, list) and
           tok.value.startswith('#')):
-        # All trailing comments 
+        # All trailing comments
         # NOTE not including comments that appear on a line by themselves
         # in this block should be indented at the same level. The block is
         # terminated by an empty line or EOF. Enumerate through each line in
@@ -310,7 +311,15 @@ def _AlignTrailingComments(final_lines):
           line_content = ''
           pc_line_lengths = []
 
+          #NOTE added by Xiao
+          contain_object = False
           for line_tok in this_line.tokens:
+
+            #NOTE added by Xiao
+            if (line_tok.value in [')', ']','}']
+              and line_tok.formatted_whitespace_prefix.startswith('\n')):
+              contain_object = True
+
             whitespace_prefix = line_tok.formatted_whitespace_prefix
 
             newline_index = whitespace_prefix.rfind('\n')
@@ -323,22 +332,22 @@ def _AlignTrailingComments(final_lines):
             '''The part is added by Xiao on the top of original yapf code
               because we don't want comments on newlines align with comments inline
             '''
-            if style.Get('ALIGN_NEWLINE_COMMENTS_WITH_INLINE_COMMENTS'):
-              if line_tok.is_comment: 
-                pc_line_lengths.append(len(line_content))
-              else:
-                line_content += '{}{}'.format(whitespace_prefix, line_tok.value)
+            # if comment starts with '\n', it will save length 0
+            if line_tok.is_comment:
+              pc_line_lengths.append(len(line_content))
             else:
-              if line_tok.is_comment and not line_tok.formatted_whitespace_prefix.startswith('\n'):
-                pc_line_lengths.append(len(line_content))
-              else:
-                line_content += '{}{}'.format(whitespace_prefix, line_tok.value)
-
+              line_content += '{}{}'.format(whitespace_prefix, line_tok.value)
 
           if pc_line_lengths:
             max_line_length = max(max_line_length, max(pc_line_lengths))
 
           all_pc_line_lengths.append(pc_line_lengths)
+
+          #NOTE added by Xiao
+          # if it's a logical line with object(dict/list/tuple)
+          # that have its items in separate lines
+          if contain_object:
+            break
 
         # Calculate the aligned column value
         max_line_length += 2
@@ -362,7 +371,7 @@ def _AlignTrailingComments(final_lines):
 
           pc_line_length_index = 0
           for line_tok in this_line.tokens:
-            if line_tok.is_comment and '\n' not in line_tok.formatted_whitespace_prefix:
+            if line_tok.is_comment:
               assert pc_line_length_index < len(pc_line_lengths)
               assert pc_line_lengths[pc_line_length_index] < aligned_col
 
@@ -370,14 +379,18 @@ def _AlignTrailingComments(final_lines):
               # we need to apply a whitespace prefix to each line.
               whitespace = ' ' * (
                   aligned_col - pc_line_lengths[pc_line_length_index] - 1)
-              pc_line_length_index += 1
-              
+
+
               ''' this is added by Xiao because we don't want comments on newlines
                   to align with comments inline
               '''
               if not style.Get('ALIGN_NEWLINE_COMMENTS_WITH_INLINE_COMMENTS'):
+                # if this comment starts with '\n', pass and go to next comment
+                if pc_line_lengths[pc_line_length_index] == 0:
+                  pc_line_length_index += 1
+                  continue
                 line_content = '{}{}'.format(whitespace, line_tok.value.strip())
-              else:                  
+              else:
                 line_content = []
 
                 for comment_line_index, comment_line in enumerate(
@@ -389,7 +402,10 @@ def _AlignTrailingComments(final_lines):
                     whitespace = ' ' * (aligned_col - 1)
 
                 line_content = '\n'.join(line_content)
-              
+
+              # after process, go to next pre comment tokens length
+              pc_line_length_index += 1
+
               # Account for initial whitespace already slated for the
               # beginning of the line.
               existing_whitespace_prefix = \
@@ -409,7 +425,6 @@ def _AlignTrailingComments(final_lines):
 
     if not processed_content:
       final_lines_index += 1
-
 
 
 def _FormatFinalLines(final_lines, verify):

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -55,7 +55,7 @@ _STYLE_HELP = dict(
     ALIGN_CLOSING_BRACKET_WITH_VISUAL_INDENT=textwrap.dedent("""\
       Align closing bracket with visual indentation."""),
     ALIGN_NEWLINE_COMMENTS_WITH_INLINE_COMMENTS=textwrap.dedent("""\
-      Align comments on newlines with the inline comments in the 
+      Align comments on newlines with the inline comments in the
       same block. This is the default setting for yapf."""),
     ALLOW_MULTILINE_LAMBDAS=textwrap.dedent("""\
       Allow lambdas to be formatted on more than one line."""),
@@ -422,7 +422,7 @@ def CreatePEP8Style():
   """Create the PEP8 formatting style."""
   return dict(
       ALIGN_CLOSING_BRACKET_WITH_VISUAL_INDENT=True,
-      ALIGN_NEWLINE_COMMENTS_WITH_INLINE_COMMENTS=False,
+      ALIGN_NEWLINE_COMMENTS_WITH_INLINE_COMMENTS=True,
       ALLOW_MULTILINE_LAMBDAS=False,
       ALLOW_MULTILINE_DICTIONARY_KEYS=False,
       ALLOW_SPLIT_BEFORE_DEFAULT_OR_NAMED_ASSIGNS=True,
@@ -513,7 +513,6 @@ def CreateYapfStyle():
   style['SPLIT_BEFORE_BITWISE_OPERATOR'] = True
   style['SPLIT_BEFORE_DOT'] = True
   style['SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN'] = True
-  style['ALIGN_NEWLINE_COMMENTS_WITH_INLINE_COMMENTS'] = True
   return style
 
 

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -54,6 +54,9 @@ def SetGlobalStyle(style):
 _STYLE_HELP = dict(
     ALIGN_CLOSING_BRACKET_WITH_VISUAL_INDENT=textwrap.dedent("""\
       Align closing bracket with visual indentation."""),
+    ALIGN_NEWLINE_COMMENTS_WITH_INLINE_COMMENTS=textwrap.dedent("""\
+      Align comments on newlines with the inline comments in the 
+      same block. This is the default setting for yapf."""),
     ALLOW_MULTILINE_LAMBDAS=textwrap.dedent("""\
       Allow lambdas to be formatted on more than one line."""),
     ALLOW_MULTILINE_DICTIONARY_KEYS=textwrap.dedent("""\
@@ -419,6 +422,7 @@ def CreatePEP8Style():
   """Create the PEP8 formatting style."""
   return dict(
       ALIGN_CLOSING_BRACKET_WITH_VISUAL_INDENT=True,
+      ALIGN_NEWLINE_COMMENTS_WITH_INLINE_COMMENTS=False,
       ALLOW_MULTILINE_LAMBDAS=False,
       ALLOW_MULTILINE_DICTIONARY_KEYS=False,
       ALLOW_SPLIT_BEFORE_DEFAULT_OR_NAMED_ASSIGNS=True,
@@ -509,6 +513,7 @@ def CreateYapfStyle():
   style['SPLIT_BEFORE_BITWISE_OPERATOR'] = True
   style['SPLIT_BEFORE_DOT'] = True
   style['SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN'] = True
+  style['ALIGN_NEWLINE_COMMENTS_WITH_INLINE_COMMENTS'] = True
   return style
 
 
@@ -607,6 +612,7 @@ def _IntOrIntListConverter(s):
 # Note: this dict has to map all the supported style options.
 _STYLE_OPTION_VALUE_CONVERTER = dict(
     ALIGN_CLOSING_BRACKET_WITH_VISUAL_INDENT=_BoolConverter,
+    ALIGN_NEWLINE_COMMENTS_WITH_INLINE_COMMENTS=_BoolConverter,
     ALLOW_MULTILINE_LAMBDAS=_BoolConverter,
     ALLOW_MULTILINE_DICTIONARY_KEYS=_BoolConverter,
     ALLOW_SPLIT_BEFORE_DEFAULT_OR_NAMED_ASSIGNS=_BoolConverter,

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -1918,20 +1918,20 @@ class HorizontallyAlignedTrailingCommentsTest(yapf_test_helper.YAPFTest):
     unformatted_code = textwrap.dedent("""\
         func( 1 ) # Line 1
         func( 2 ) # Line 2
-        d = {key1: value1, key2: value2, key3: value3} # Line 3
+        d = {key1: value1, key2: value2, key3: value3,} # Line 3
         func( 3 ) # Line 4
         func( 4 ) # line 5
         """)  # noqa
     expected_formatted_code = textwrap.dedent("""\
-        func( 1 )               # Line 1
-        func( 2 )               # Line 2
+        func(1)                 # Line 1
+        func(2)                 # Line 2
         d = {
             key1: value1,
             key2: value2,
             key3: value3,
         }                       # Line 3
-        func( 3 )     # Line 4
-        func( 4 )     # line 5
+        func(3)       # Line 4
+        func(4)       # line 5
         """)
     self._Check(unformatted_code, expected_formatted_code)
 

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -26,7 +26,7 @@ import unittest
 
 from lib2to3.pgen2 import tokenize
 
-from yapf.yapflib import errors
+from yapf.yapflib import errors, reformatter
 from yapf.yapflib import py3compat
 from yapf.yapflib import style
 from yapf.yapflib import yapf_api
@@ -1874,6 +1874,68 @@ class HorizontallyAlignedTrailingCommentsTest(yapf_test_helper.YAPFTest):
         a_longer_statement      # comment 2
         """)
     self._Check(unformatted_code, expected_formatted_code)
+
+  #NOTE test if don't align newline comments with inline comments
+  def testNewlineCommentsInsideInlineComment(self):
+    try:
+        style.SetGlobalStyle(
+            style.CreateStyleFromConfig('{align_newline_comments_with_inline_comments:false,'
+            'spaces_before_comment:15, 25,35}'))
+        unformatted_code = textwrap.dedent("""\
+            if True:
+                if True:
+                    if True:
+                        func(1)     # comment 1
+                        func(2) # comment 2
+                        # comment 3
+                        func(3)                             # comment 4 inline
+                                                            # comment 4 newline
+                                                            # comment 4 newline
+
+                                                            # comment 5 Not aligned
+            """)  # noqa
+        expected_formatted_code = textwrap.dedent("""\
+            if True:
+                if True:
+                    if True:
+                        func(1)               # comment 1
+                        func(2)               # comment 2
+                        # comment 3
+                        func(3)               # comment 4 inline
+                        # comment 4 newline
+                        # comment 4 newline
+
+                        # comment 5 Not aligned
+            """)
+        llines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
+        self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(llines))
+    finally:
+        style.SetGlobalStyle(self._OwnStyle())
+
+  # test when there is an object with newline entries in between
+  def testObjectWithNewlineEntriesInBetween(self):
+
+    unformatted_code = textwrap.dedent("""\
+        func( 1 ) # Line 1
+        func( 2 ) # Line 2
+        d = {key1: value1, key2: value2, key3: value3} # Line 3
+func( 3 )     # Line 4
+func( 4 )     # line 5
+        """)  # noqa
+    expected_formatted_code = textwrap.dedent("""\
+        if True:
+            if True:
+                if True:
+                    func(1)               # comment 1
+                    func(2)               # comment 2
+                    # comment 3
+                    func(3)               # comment 4 inline
+                    # comment 4 newline
+                    # comment 4 newline
+
+                    # comment 5 Not aligned
+        """)
+
 
 
 class _SpacesAroundDictListTupleTestImpl(unittest.TestCase):

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -1919,23 +1919,21 @@ class HorizontallyAlignedTrailingCommentsTest(yapf_test_helper.YAPFTest):
         func( 1 ) # Line 1
         func( 2 ) # Line 2
         d = {key1: value1, key2: value2, key3: value3} # Line 3
-func( 3 )     # Line 4
-func( 4 )     # line 5
+        func( 3 ) # Line 4
+        func( 4 ) # line 5
         """)  # noqa
     expected_formatted_code = textwrap.dedent("""\
-        if True:
-            if True:
-                if True:
-                    func(1)               # comment 1
-                    func(2)               # comment 2
-                    # comment 3
-                    func(3)               # comment 4 inline
-                    # comment 4 newline
-                    # comment 4 newline
-
-                    # comment 5 Not aligned
+        func( 1 )               # Line 1
+        func( 2 )               # Line 2
+        d = {
+            key1: value1,
+            key2: value2,
+            key3: value3,
+        }                       # Line 3
+        func( 3 )     # Line 4
+        func( 4 )     # line 5
         """)
-
+    self._Check(unformatted_code, expected_formatted_code)
 
 
 class _SpacesAroundDictListTupleTestImpl(unittest.TestCase):


### PR DESCRIPTION
**Hello yapf founders!**
I want to share one knob and one change for the *AlignTrailingComments* feature.

### The knob: *ALIGN_NEWLINE_COMMENTS_WITH_INLINE_COMMENTS*
This is a style option I added for when we do not want to align the newline comments with the inline comments in the same alignment block.
- The default setting is **True**. When set to **False**, newline comments won't align with inline comments.
- For example, instead of 

  ```
  if 1:
  encoding_bom = None
  if ( encoding.endswith( '-sig' ) or encoding.endswith( '-bom' ) ):
    encoding = encoding[ :-4 ]
    if ( encoding == 'utf-8' ):          # comment inline
                                         # comment newline
      encoding_bom = codecs.BOM_UTF16_BE
    else:
                                         #=========Comment Newlines=============================
                                         # I18N_MESSAGE | 210620850
                                         # de | BOM nicht unterstützt für Encoding '${enc}'.
                                         # en | BOM not supported for encoding '${enc}'.
                                         #======================================================
      result[ 'success' ] = False
      result[ 'error_code' ] = 210620850 # comment inline
  ```
- we want
  ```
  if 1:
  encoding_bom = None
  if ( encoding.endswith( '-sig' ) or encoding.endswith( '-bom' ) ):
    encoding = encoding[ :-4 ]
    if ( encoding == 'utf-8' ):          # comment inline
      # comment newline
      encoding_bom = codecs.BOM_UTF16_BE
    else:
      #=========Comment Newlines=============================
      # I18N_MESSAGE | 210620850
      # de | BOM nicht unterstützt für Encoding '${enc}'.
      # en | BOM not supported for encoding '${enc}'.
      #======================================================
      result[ 'success' ] = False
      result[ 'error_code' ] = 210620850 # comment inline
  ```

### One change
Another change I added is when there is an object(dictionary, argument list, list, function call) with its entries on separate lines with its closing bracket also on a separate line,  it starts a new alignment block.
For example:
```
func( 1 )               # Line 1
func( 2 )               # Line 2
d = {
    key1: value1,
    key2: value2,
    key3: value3,
}                       # Line 3
func( 3 )     # Line 4
func( 4 )     # line 5
```
### Finally
- The knob is added in *style.py*. The default setting is **True**.
- The tests for the new knob and new alignment after the object with entries on separate lines are added in *yapf_test.py*.

<br>
