### PR TITLE
Fix fallback behavior on invalid/empty line ranges.

### DIFF
--- a/yapf/yapflib/yapf_api.py
+++ b/yapf/yapflib/yapf_api.py
@@ -275,7 +275,7 @@ def _LineRangesToSet(line_ranges):
 
 def _MarkLinesToFormat(llines, lines):
   """Skip sections of code that we shouldn't reformat."""
-  if lines:
+  if lines is not None:
     for uwline in llines:
       uwline.disable = not lines.intersection(
           range(uwline.lineno, uwline.last.lineno + 1))


### PR DESCRIPTION
The existing logic behaves poorly when the output of _LineRangesToSet is empty (note: not `None`, an empty set). Instead of restricting formatting to the empty set of lines (i.e. suppressing all formats), the current behavior lifts all line constraints and formats the whole file. It's perhaps not a bug but I think it's surprising behavior and the improper response to unexpected input.