### PR TITLE
Add style setting to allow for function continuation indent width

### DIFF
--- a/yapf/yapflib/format_decision_state.py
+++ b/yapf/yapflib/format_decision_state.py
@@ -921,8 +921,12 @@ class FormatDecisionState(object):
       return column
     align_style = style.Get('CONTINUATION_ALIGN_STYLE')
     if align_style == 'FIXED':
-      return ((self.line.depth * style.Get('INDENT_WIDTH')) +
-              style.Get('CONTINUATION_INDENT_WIDTH'))
+      if _IsFunctionDef(self.line.first):
+        indent_width = style.GetOrDefault('FUNCTION_CONTINUATION_INDENT_WIDTH',
+                                          style.Get('CONTINUATION_INDENT_WIDTH'))
+      else:
+        indent_width = style.Get('CONTINUATION_INDENT_WIDTH')
+      return ((self.line.depth * style.Get('INDENT_WIDTH')) + indent_width)
     if align_style == 'VALIGN-RIGHT':
       indent_width = style.Get('INDENT_WIDTH')
       return indent_width * int((column + indent_width - 1) / indent_width)

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -168,6 +168,9 @@ _STYLE_HELP = dict(
         config = {
             'key1': 'value1'
         }"""),
+    FUNCTION_CONTINUATION_INDENT_WIDTH=textwrap.dedent("""\
+      Indent width used for function definition line continuations. Defaults to
+      CONTINUATION_INDENT_WIDTH."""),
     I18N_COMMENT=textwrap.dedent("""\
       The regex for an i18n comment. The presence of this comment stops
       reformatting of that line, because the comments are required to be
@@ -438,6 +441,7 @@ def CreatePEP8Style():
       DISABLE_ENDING_COMMA_HEURISTIC=False,
       EACH_DICT_ENTRY_ON_SEPARATE_LINE=True,
       FORCE_MULTILINE_DICT=False,
+      FUNCTION_CONTINUATION_INDENT_WIDTH=4,
       I18N_COMMENT='',
       I18N_FUNCTION_CALL='',
       INDENT_DICTIONARY_VALUE=False,
@@ -626,6 +630,7 @@ _STYLE_OPTION_VALUE_CONVERTER = dict(
     DISABLE_ENDING_COMMA_HEURISTIC=_BoolConverter,
     EACH_DICT_ENTRY_ON_SEPARATE_LINE=_BoolConverter,
     FORCE_MULTILINE_DICT=_BoolConverter,
+    FUNCTION_CONTINUATION_INDENT_WIDTH=int,
     I18N_COMMENT=str,
     I18N_FUNCTION_CALL=_StringListConverter,
     INDENT_DICTIONARY_VALUE=_BoolConverter,


### PR DESCRIPTION
There is no style setting to deal with continuations for a function
definition differently than other continuations. As is,
CONTINUATION_INDENT_WIDTH is uniformly applied. A new setting,
FUNCTION_CONTINUATION_INDENT_WIDTH, allows for function definition
continuations to be indented differently. For example, 8 spaces
instead of the common 4 sets off the definition continuation more
clearly. The default is to use CONTINUATION_INDENT_WIDTH otherwise.