### PR TITLE
Generated dicts also have keys and values for rules to apply

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@
 ### Changes
 - Moved 'pytree' parsing tools into its own subdirectory.
 - Add support for Python 3.10.
+- Format generated dicts with respect to same rules as regular dicts
 ### Fixed
 - Split line before all comparison operators.
 

--- a/yapf/yapflib/format_decision_state.py
+++ b/yapf/yapflib/format_decision_state.py
@@ -1031,6 +1031,8 @@ class FormatDecisionState(object):
     current = opening.next_token.next_token
 
     while current and current != closing:
+      if subtypes.DICT_SET_GENERATOR in current.subtypes:
+        break
       if subtypes.DICTIONARY_KEY in current.subtypes:
         prev = PreviousNonCommentToken(current)
         if prev.value == ',':

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -1624,6 +1624,18 @@ s = 'foo \\
     llines = yapf_test_helper.ParseAndUnwrap(code)
     self.assertCodeEqual(code, reformatter.Reformat(llines))
 
+    unformatted_code = textwrap.dedent("""\
+        foo = {
+            x: x
+            for x in fnord
+        }
+        """)  # noqa
+    expected_code = textwrap.dedent("""\
+        foo = {x: x for x in fnord}
+        """)
+    llines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
+    self.assertCodeEqual(expected_code, reformatter.Reformat(llines))
+
   def testUnaryOpInDictionaryValue(self):
     code = textwrap.dedent("""\
         beta = "123"
@@ -3123,8 +3135,10 @@ my_dict = {
     try:
       style.SetGlobalStyle(
           style.CreateStyleFromConfig('{force_multiline_dict: true}'))
-      unformatted_code = textwrap.dedent(
-          "responseDict = {'childDict': {'spam': 'eggs'}}\n")
+      unformatted_code = textwrap.dedent("""\
+        responseDict = {'childDict': {'spam': 'eggs'}}
+        generatedDict = {x: x for x in 'value'}
+      """)
       llines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
       actual = reformatter.Reformat(llines)
       expected = textwrap.dedent("""\
@@ -3132,6 +3146,9 @@ my_dict = {
             'childDict': {
                 'spam': 'eggs'
             }
+        }
+        generatedDict = {
+            x: x for x in 'value'
         }
       """)
       self.assertCodeEqual(expected, actual)
@@ -3144,6 +3161,7 @@ my_dict = {
           style.CreateStyleFromConfig('{force_multiline_dict: false}'))
       unformatted_code = textwrap.dedent("""\
         responseDict = {'childDict': {'spam': 'eggs'}}
+        generatedDict = {x: x for x in 'value'}
       """)
       expected_formatted_code = unformatted_code
       llines = yapf_test_helper.ParseAndUnwrap(unformatted_code)

--- a/yapftests/subtype_assigner_test.py
+++ b/yapftests/subtype_assigner_test.py
@@ -131,6 +131,36 @@ class SubtypeAssignerTest(yapf_test_helper.YAPFTest):
 
   def testSetComprehension(self):
     code = textwrap.dedent("""\
+        def foo(value):
+          return {value.lower()}
+        """)
+    llines = yapf_test_helper.ParseAndUnwrap(code)
+    self._CheckFormatTokenSubtypes(llines, [
+        [
+            ('def', {subtypes.NONE}),
+            ('foo', {subtypes.FUNC_DEF}),
+            ('(', {subtypes.NONE}),
+            ('value', {
+                subtypes.NONE,
+                subtypes.PARAMETER_START,
+                subtypes.PARAMETER_STOP,
+            }),
+            (')', {subtypes.NONE}),
+            (':', {subtypes.NONE}),
+        ],
+        [
+            ('return', {subtypes.NONE}),
+            ('{', {subtypes.NONE}),
+            ('value', {subtypes.NONE}),
+            ('.', {subtypes.NONE}),
+            ('lower', {subtypes.NONE}),
+            ('(', {subtypes.NONE}),
+            (')', {subtypes.NONE}),
+            ('}', {subtypes.NONE}),
+        ],
+    ])
+
+    code = textwrap.dedent("""\
         def foo(strs):
           return {s.lower() for s in strs}
         """)
@@ -163,6 +193,209 @@ class SubtypeAssignerTest(yapf_test_helper.YAPFTest):
             ('s', {subtypes.COMP_FOR}),
             ('in', {subtypes.COMP_FOR}),
             ('strs', {subtypes.COMP_FOR}),
+            ('}', {subtypes.NONE}),
+        ],
+    ])
+
+    code = textwrap.dedent("""\
+        def foo(strs):
+          return {s + s.lower() for s in strs}
+        """)
+    llines = yapf_test_helper.ParseAndUnwrap(code)
+    self._CheckFormatTokenSubtypes(llines, [
+        [
+            ('def', {subtypes.NONE}),
+            ('foo', {subtypes.FUNC_DEF}),
+            ('(', {subtypes.NONE}),
+            ('strs', {
+                subtypes.NONE,
+                subtypes.PARAMETER_START,
+                subtypes.PARAMETER_STOP,
+            }),
+            (')', {subtypes.NONE}),
+            (':', {subtypes.NONE}),
+        ],
+        [
+            ('return', {subtypes.NONE}),
+            ('{', {subtypes.NONE}),
+            ('s', {subtypes.COMP_EXPR}),
+            ('+', {subtypes.BINARY_OPERATOR, subtypes.COMP_EXPR}),
+            ('s', {subtypes.COMP_EXPR}),
+            ('.', {subtypes.COMP_EXPR}),
+            ('lower', {subtypes.COMP_EXPR}),
+            ('(', {subtypes.COMP_EXPR}),
+            (')', {subtypes.COMP_EXPR}),
+            ('for', {
+                subtypes.DICT_SET_GENERATOR,
+                subtypes.COMP_FOR,
+            }),
+            ('s', {subtypes.COMP_FOR}),
+            ('in', {subtypes.COMP_FOR}),
+            ('strs', {subtypes.COMP_FOR}),
+            ('}', {subtypes.NONE}),
+        ],
+    ])
+
+    code = textwrap.dedent("""\
+        def foo(strs):
+          return {c.lower() for s in strs for c in s}
+        """)
+    llines = yapf_test_helper.ParseAndUnwrap(code)
+    self._CheckFormatTokenSubtypes(llines, [
+        [
+            ('def', {subtypes.NONE}),
+            ('foo', {subtypes.FUNC_DEF}),
+            ('(', {subtypes.NONE}),
+            ('strs', {
+                subtypes.NONE,
+                subtypes.PARAMETER_START,
+                subtypes.PARAMETER_STOP,
+            }),
+            (')', {subtypes.NONE}),
+            (':', {subtypes.NONE}),
+        ],
+        [
+            ('return', {subtypes.NONE}),
+            ('{', {subtypes.NONE}),
+            ('c', {subtypes.COMP_EXPR}),
+            ('.', {subtypes.COMP_EXPR}),
+            ('lower', {subtypes.COMP_EXPR}),
+            ('(', {subtypes.COMP_EXPR}),
+            (')', {subtypes.COMP_EXPR}),
+            ('for', {
+                subtypes.DICT_SET_GENERATOR,
+                subtypes.COMP_FOR,
+                subtypes.COMP_EXPR,
+            }),
+            ('s', {subtypes.COMP_FOR, subtypes.COMP_EXPR}),
+            ('in', {subtypes.COMP_FOR, subtypes.COMP_EXPR}),
+            ('strs', {subtypes.COMP_FOR, subtypes.COMP_EXPR}),
+            ('for', {
+                subtypes.DICT_SET_GENERATOR,
+                subtypes.COMP_FOR,
+            }),
+            ('c', {subtypes.COMP_FOR}),
+            ('in', {subtypes.COMP_FOR}),
+            ('s', {subtypes.COMP_FOR}),
+            ('}', {subtypes.NONE}),
+        ],
+    ])
+
+  def testDictComprehension(self):
+    code = textwrap.dedent("""\
+        def foo(value):
+          return {value: value.lower()}
+        """)
+    llines = yapf_test_helper.ParseAndUnwrap(code)
+    self._CheckFormatTokenSubtypes(llines, [
+        [
+            ('def', {subtypes.NONE}),
+            ('foo', {subtypes.FUNC_DEF}),
+            ('(', {subtypes.NONE}),
+            ('value', {
+                subtypes.NONE,
+                subtypes.PARAMETER_START,
+                subtypes.PARAMETER_STOP,
+            }),
+            (')', {subtypes.NONE}),
+            (':', {subtypes.NONE}),
+        ],
+        [
+            ('return', {subtypes.NONE}),
+            ('{', {subtypes.NONE}),
+            ('value', {subtypes.DICTIONARY_KEY, subtypes.DICTIONARY_KEY_PART}),
+            (':', {subtypes.NONE}),
+            ('value', {subtypes.DICTIONARY_VALUE}),
+            ('.', {subtypes.NONE}),
+            ('lower', {subtypes.NONE}),
+            ('(', {subtypes.NONE}),
+            (')', {subtypes.NONE}),
+            ('}', {subtypes.NONE}),
+        ],
+    ])
+
+    code = textwrap.dedent("""\
+        def foo(strs):
+          return {s: s.lower() for s in strs}
+        """)
+    llines = yapf_test_helper.ParseAndUnwrap(code)
+    self._CheckFormatTokenSubtypes(llines, [
+        [
+            ('def', {subtypes.NONE}),
+            ('foo', {subtypes.FUNC_DEF}),
+            ('(', {subtypes.NONE}),
+            ('strs', {
+                subtypes.NONE,
+                subtypes.PARAMETER_START,
+                subtypes.PARAMETER_STOP,
+            }),
+            (')', {subtypes.NONE}),
+            (':', {subtypes.NONE}),
+        ],
+        [
+            ('return', {subtypes.NONE}),
+            ('{', {subtypes.NONE}),
+            ('s', {subtypes.DICTIONARY_KEY, subtypes.DICTIONARY_KEY_PART, subtypes.COMP_EXPR}),
+            (':', {subtypes.COMP_EXPR}),
+            ('s', {subtypes.DICTIONARY_VALUE, subtypes.COMP_EXPR}),
+            ('.', {subtypes.COMP_EXPR}),
+            ('lower', {subtypes.COMP_EXPR}),
+            ('(', {subtypes.COMP_EXPR}),
+            (')', {subtypes.COMP_EXPR}),
+            ('for', {
+                subtypes.DICT_SET_GENERATOR,
+                subtypes.COMP_FOR,
+            }),
+            ('s', {subtypes.COMP_FOR}),
+            ('in', {subtypes.COMP_FOR}),
+            ('strs', {subtypes.COMP_FOR}),
+            ('}', {subtypes.NONE}),
+        ],
+    ])
+
+    code = textwrap.dedent("""\
+        def foo(strs):
+          return {c: c.lower() for s in strs for c in s}
+        """)
+    llines = yapf_test_helper.ParseAndUnwrap(code)
+    self._CheckFormatTokenSubtypes(llines, [
+        [
+            ('def', {subtypes.NONE}),
+            ('foo', {subtypes.FUNC_DEF}),
+            ('(', {subtypes.NONE}),
+            ('strs', {
+                subtypes.NONE,
+                subtypes.PARAMETER_START,
+                subtypes.PARAMETER_STOP,
+            }),
+            (')', {subtypes.NONE}),
+            (':', {subtypes.NONE}),
+        ],
+        [
+            ('return', {subtypes.NONE}),
+            ('{', {subtypes.NONE}),
+            ('c', {subtypes.DICTIONARY_KEY, subtypes.DICTIONARY_KEY_PART, subtypes.COMP_EXPR}),
+            (':', {subtypes.COMP_EXPR}),
+            ('c', {subtypes.DICTIONARY_VALUE, subtypes.COMP_EXPR}),
+            ('.', {subtypes.COMP_EXPR}),
+            ('lower', {subtypes.COMP_EXPR}),
+            ('(', {subtypes.COMP_EXPR}),
+            (')', {subtypes.COMP_EXPR}),
+            ('for', {
+                subtypes.DICT_SET_GENERATOR,
+                subtypes.COMP_FOR,
+                subtypes.COMP_EXPR,
+            }),
+            ('s', {subtypes.COMP_FOR, subtypes.COMP_EXPR}),
+            ('in', {subtypes.COMP_FOR, subtypes.COMP_EXPR}),
+            ('strs', {subtypes.COMP_FOR, subtypes.COMP_EXPR}),
+            ('for', {
+                subtypes.DICT_SET_GENERATOR,
+                subtypes.COMP_FOR,
+            }),
+            ('c', {subtypes.COMP_FOR}),
+            ('in', {subtypes.COMP_FOR}),
+            ('s', {subtypes.COMP_FOR}),
             ('}', {subtypes.NONE}),
         ],
     ])


### PR DESCRIPTION
The general idea:

If
```python
responseDict = {'childDict': {'spam': 'eggs'}}
```
is formatted as 
```python
responseDict = {
    'childDict': {
        'spam': 'eggs'
    }
}
```
so should
```python
generatedDict = {x: x for x in 'value'}
```
be formatted as 
```python
generatedDict = {
    x: x for x in 'value'
}
```
assuming `force_multiline_dict` is enabled. Also allows to achieve the following format if `split_before_dict_set_generator` is enabled:
```python
generatedDict = {
    x: x
    for x in 'value'
}
```