### PR TITLE
added knob count to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -390,6 +390,8 @@ Options::
 Knobs
 =====
 
+There are 60 knobs in total.
+
 ``ALIGN_CLOSING_BRACKET_WITH_VISUAL_INDENT``
     Align closing bracket with visual indentation.
 


### PR DESCRIPTION
I think it would be best to add overall number of knobs. I tried to play and tweak with all of them, but I wasn't sure if I had all of them in my **pyproject.toml** file. So I think there are *some* people who'd like to also have an exact number of available knobs. It doesn't clutter the README that much and it's easy to update the number in case of modifying the number of knobs.

P. S. I counted them using `print(len(_STYLE_HELP))` in `yapf/yapflib/style.py`