### PR TITLE
Add --print-modified to print modified files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@
 ## [0.40.0] UNRELEASED
 ### Added
 - Support for Python 3.11
+- Add the `--print-modified` flag to print out file names of modified files when
+  running in in-place mode.
 ### Removed
 - Support for Python <3.7
 

--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,7 @@ Options::
       --no-local-style      don't search for local style definition
       -p, --parallel        run YAPF in parallel when formatting multiple
                             files. Requires concurrent.futures in Python 2.X
+      -m, --print-modified  print out file names of modified files
       -vv, --verbose        print out file names while processing
 
 

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -505,6 +505,16 @@ class CommandLineTest(unittest.TestCase):
         reformatted_code = fd.read()
     self.assertEqual(reformatted_code, expected_formatted_code)
 
+  def testPrintModified(self):
+    for unformatted_code, has_change in [('1==2', True), ('1 == 2', False)]:
+      with utils.TempFileContents(
+          self.test_tmpdir, unformatted_code, suffix='.py') as filepath:
+        output = subprocess.check_output(
+            YAPF_BINARY + ['--in-place', '--print-modified', filepath],
+            text=True)
+        check = self.assertIn if has_change else self.assertNotIn
+        check(f'Formatted {filepath}', output)
+
   def testReadFromStdin(self):
     unformatted_code = textwrap.dedent("""\
         def foo():


### PR DESCRIPTION
Prints modified files when in place mode is used. This helps debugging formatting issues and makes developers more aware of the changes made by yapf.