### PR TITLE
ci.yml: Stop limiting push-CI to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ name: YAPF
 on:
   pull_request:
   push:
-    branches: 'main'
 
 jobs:
   build:


### PR DESCRIPTION
.. to ease pull requests from topic branches.

Previously, external contributors like me had to pick from these non-ideal options:
- develop on the `main` branch in their fork which e.g. doesn't scale
- create commits to adjust CI config to only revert them again later when creating a pull request
- wait for someone to approve the CI run right in https://github.com/google/yapf

Thanks for your consideration! :pray: 