### PR TITLE
Make GitHub Dependabot keep the GitHub Actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    commit-message:
+      include: "scope"
+      prefix: "Actions"
+    directory: "/"
+    labels:
+      - "enhancement"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Follow-up to #1073

Makes GitHub Dependabot send pull requests like https://github.com/gentoo-ev/www.gentoo-ev.org/pull/5/files .

CC @bwendling 