### PR TITLE
Remove unnecessary package toml from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         python -m pip install --upgrade pip
     - name: Lint with flake8
       run: |
-        python -m pip install toml flake8
+        python -m pip install flake8
         flake8 . --statistics
     - name: Test with pytest
       run: |


### PR DESCRIPTION
I'm not sure why toml was ever included as a flake8 requirement, but I don't think it is required anymore.