### PR TITLE
Make CI keep pre-commit hooks up to date

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,0 +1,63 @@
+# Copyright (c) 2023 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under the Apache License Version 2.0
+
+name: Keep pre-commit hooks up to date
+
+on:
+  schedule:
+    - cron: '0 16 * * 5'  # Every Friday 4pm
+  workflow_dispatch:
+
+# NOTE: This will drop all permissions from GITHUB_TOKEN except metadata read,
+#       and then (re)add the ones listed below:
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  pre_commit_autoupdate:
+    name: Detect outdated pre-commit hooks
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435  # v4.5.0
+        with:
+          python-version: 3.11
+
+      - name: Install pre-commit
+        run: |-
+          pip install \
+            --disable-pip-version-check \
+            --no-warn-script-location \
+            --user \
+            pre-commit
+          echo "PATH=${HOME}/.local/bin:${PATH}" >> "${GITHUB_ENV}"
+
+      - name: Check for outdated hooks
+        run: |-
+          pre-commit autoupdate
+          git diff -- .pre-commit-config.yaml
+
+      - name: Create pull request from changes (if any)
+        id: create-pull-request
+        uses: peter-evans/create-pull-request@5b4a9f6a9e2af26e5f02351490b90d01eb8ec1e5  # v5.0.0
+        with:
+          author: 'pre-commit <pre-commit@tools.invalid>'
+          base: main
+          body: |-
+            For your consideration.
+
+            :warning: Please **CLOSE AND RE-OPEN** this pull request so that [further workflow runs get triggered](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs) for this pull request.
+          branch: precommit-autoupdate
+          commit-message: "pre-commit: Autoupdate"
+          delete-branch: true
+          draft: true
+          labels: enhancement
+          title: "pre-commit: Autoupdate"
+
+      - name: Log pull request URL
+        if: "${{ steps.create-pull-request.outputs.pull-request-url }}"
+        run: |
+          echo "Pull request URL is: ${{ steps.create-pull-request.outputs.pull-request-url }}"


### PR DESCRIPTION
Was split off of #1096 as suggested at https://github.com/google/yapf/pull/1096#issuecomment-1564727656 .

I'm using a 99% identical approach at multiple other places happily, e.g. pull request https://github.com/hartwork/git-delete-merged-branches/pull/132 was created the same way, also https://github.com/git-big-picture/git-big-picture/pull/318 and so on.

If you like this approach: after the merge, if you trigger workflow `pre_commit_autoupdate` manually it will create a pull request updating the isort pre-commit hook to `v4.4.0` for us. If you don't, it will do that next Friday.

For the CI to be able to create pull requests, this setting on the repository is needed:

![permissions](https://github.com/google/yapf/assets/1577132/66694cb2-0736-4c2b-b937-31cacf470309)

Let me know what you think :beers: 

CC @bwendling @Spitfire1900
