### PR TITLE
Fix unexpected whitespace removal outside line range

### DIFF
--- a/yapf/pytree/pytree_unwrapper.py
+++ b/yapf/pytree/pytree_unwrapper.py
@@ -85,6 +85,7 @@ class PyTreeUnwrapper(pytree_visitor.PyTreeVisitor):
   def __init__(self):
     # A list of all logical lines finished visiting so far.
     self._logical_lines = []
+    self.prefix = ""
 
     # Builds up a "current" logical line while visiting pytree nodes. Some nodes
     # will finish a line and start a new one.
@@ -297,12 +298,17 @@ class PyTreeUnwrapper(pytree_visitor.PyTreeVisitor):
     Arguments:
       leaf: the leaf to visit.
     """
+    self.prefix += leaf.prefix
     if leaf.type in _WHITESPACE_TOKENS:
       self._StartNewLine()
+      if leaf.type == grammar_token.NEWLINE:
+        self.prefix += "\n"
     elif leaf.type != grammar_token.COMMENT or leaf.value.strip():
       # Add non-whitespace tokens and comments that aren't empty.
       self._cur_logical_line.AppendToken(
-          format_token.FormatToken(leaf, pytree_utils.NodeName(leaf)))
+          format_token.FormatToken(leaf, pytree_utils.NodeName(leaf),
+                                   self.prefix))
+      self.prefix = ""
 
 
 _BRACKET_MATCH = {')': '(', '}': '{', ']': '['}

--- a/yapf/yapflib/format_token.py
+++ b/yapf/yapflib/format_token.py
@@ -82,7 +82,7 @@ class FormatToken(object):
     newlines: The number of newlines needed before this token.
   """
 
-  def __init__(self, node, name):
+  def __init__(self, node, name, prefix):
     """Constructor.
 
     Arguments:
@@ -95,6 +95,7 @@ class FormatToken(object):
     self.column = node.column
     self.lineno = node.lineno
     self.value = node.value
+    self.prefix = prefix
 
     if self.is_continuation:
       self.value = node.value.rstrip()

--- a/yapf/yapflib/reformatter.py
+++ b/yapf/yapflib/reformatter.py
@@ -19,11 +19,13 @@ can be merged together are. The best formatting is returned as a string.
   Reformat(): the main function exported by this module.
 """
 
+import json
 import collections
 import heapq
 import re
 from lib2to3 import pytree
 from lib2to3.pgen2 import token
+import sys
 
 from yapf.pytree import pytree_utils
 from yapf.yapflib import format_decision_state
@@ -73,6 +75,21 @@ def Reformat(llines, verify=False, lines=None):
     if lline.disable or _LineHasContinuationMarkers(lline):
       _RetainHorizontalSpacing(lline)
       _RetainRequiredVerticalSpacing(lline, prev_line, lines)
+      if not _LineHasContinuationMarkers(lline):
+        for token in lline.tokens:
+          # print(
+          #     repr(token.value) + ":" + str(token.lineno) + ":" +
+          #     json.dumps(token.prefix) + ":" +
+          #     json.dumps(token.whitespace_prefix), file=sys.stderr)
+          if token.prefix:
+            prefix_new = token.whitespace_prefix.split("\n")
+            if len(prefix_new) >= 2:
+              prefix_old = token.prefix.split("\n")
+              offset = len(prefix_new) - len(prefix_old)
+              prefix = prefix_new[0:max(0, offset)] + prefix_old[
+                  max(0, -offset):-1] + prefix_new[-1:]
+              token.whitespace_prefix = "\n".join(prefix)
+              # print("--> " + repr(token.whitespace_prefix), file=sys.stderr)
       _EmitLineUnformatted(state)
 
     elif (_LineContainsPylintDisableLineTooLong(lline) or
@@ -399,7 +416,12 @@ def _FormatFinalLines(final_lines, verify):
     for tok in line.tokens:
       if not tok.is_pseudo:
         formatted_line.append(tok.formatted_whitespace_prefix)
-        formatted_line.append(tok.value)
+        # print(
+        #     repr(tok.formatted_whitespace_prefix),
+        #     repr(tok.value),
+        #     file=sys.stderr)
+        formatted_line.append("\n".join(map(str.rstrip, tok.value.split(
+            "\n"))) if not line.disable and tok.is_comment else tok.value)
       elif (not tok.next_token.whitespace_prefix.startswith('\n') and
             not tok.next_token.whitespace_prefix.startswith(' ')):
         if (tok.previous_token.value == ':' or


### PR DESCRIPTION
* save the whitespace prefix in the pytree node even for those occurring with comments
* disable the comment splicer's removal of trailing whitespace
* add back the whitespace before emitting unformatted line
* remove trailing whitespace in comments for enabled lines later when printing

TODO:
* extensive testing is necessary as this method is like a hack
* this still will remove trailing whitespace in line just before line range and will ignore trailing whitespace in last line of line range