### PR TITLE
pypi: include missing `Grammar.txt` and `PatternGrammar.txt`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include .coveragerc .editorconfig .flake8 plugins/README.md
 include plugins/vim/autoload/yapf.vim plugins/vim/plugin/yapf.vim pylintrc
 include .style.yapf tox.ini .travis.yml .vimrc
 include third_party/yapf_third_party/_ylib2to3/Grammar.txt
+include third_party/yapf_third_party/_ylib2to3/PatternGrammar.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include HACKING.rst LICENSE AUTHORS CHANGELOG CONTRIBUTING.md CONTRIBUTORS
 include .coveragerc .editorconfig .flake8 plugins/README.md
 include plugins/vim/autoload/yapf.vim plugins/vim/plugin/yapf.vim pylintrc
 include .style.yapf tox.ini .travis.yml .vimrc
+include third_party/yapf_third_party/_ylib2to3/Grammar.txt


### PR DESCRIPTION
fixes #1107

relates to https://github.com/Homebrew/homebrew-core/pull/133505