### PR TITLE
setup.py: Require setuptools >=58.5.0 (fixes #1107)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,9 @@ with codecs.open('README.md', 'r', 'utf-8') as fd:
       },
       include_package_data=True,
       python_requires='>=3.7',
+      setup_requires=[
+          'setuptools>=58.5.0',  # for include_package_data fix (issue #1107)
+      ],
       install_requires=[
           'importlib-metadata>=6.6.0',
           'platformdirs>=3.5.1',


### PR DESCRIPTION
.. so that `python3 setup.py sdist` ends up including these four files in the resulting distribution source tarball:

- `/third_party/yapf_third_party/yapf_diff/LICENSE`
- `/third_party/yapf_third_party/_ylib2to3/Grammar.txt`
- `/third_party/yapf_third_party/_ylib2to3/LICENSE`
- `/third_party/yapf_third_party/_ylib2to3/PatternGrammar.txt`

Fixes #1107

CC @bwendling 