### PR TITLE
Add default workspace recommendations for vscode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,7 @@
         "ms-python.isort"
     ],
     // These are remarked as extenstions you should disable for this workspace.
-    // VSCode does not support disabling extensions SCM.
+    // VSCode does not support disabling extensions via workspace config files.
     "unwantedRecommendations": [
         "ms-python.black-formatter",
         "ms-python.pylint"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,8 +3,8 @@
         "eeyore.yapf",
         "dangmai.workspace-default-settings",
         "ms-python.flake8",
+        "ms-python.isort",
         "ms-python.python",
-        "ms-python.isort"
     ],
     // These are remarked as extenstions you should disable for this workspace.
     // VSCode does not support disabling extensions via workspace config files.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,15 @@
+{
+    "recommendations": [
+        "eeyore.yapf",
+        "dangmai.workspace-default-settings",
+        "ms-python.flake8",
+        "ms-python.python",
+        "ms-python.isort"
+    ],
+    // These are remarked as extenstions you should disable for this workspace.
+    // VSCode does not support disabling extensions SCM.
+    "unwantedRecommendations": [
+        "ms-python.black-formatter",
+        "ms-python.pylint"
+    ]
+}

--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -1,0 +1,30 @@
+{
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": true
+    },
+    "files.insertFinalNewline": true,
+    "files.trimFinalNewlines": true,
+    "[python]": {
+        "diffEditor.ignoreTrimWhitespace": false,
+        "editor.defaultFormatter": "eeyore.yapf",
+        "editor.formatOnSaveMode": "file",
+        "editor.formatOnSave": true,
+        "editor.wordBasedSuggestions": false,
+        "files.trimTrailingWhitespace": true,
+    },
+    "python.analysis.typeCheckingMode": "basic",
+    "python.languageServer": "Pylance",
+    "files.exclude": {
+        "**/*$py.class": true
+    },
+    "json.schemas": [
+        {
+            "fileMatch": [
+                "/.vscode/settings.default.json"
+            ],
+            "url": "vscode://schemas/settings/folder"
+        }
+    ],
+    "workspace-default-settings.runOnActivation": true,
+    "workspace-default-settings.jsonIndentation": 4
+}


### PR DESCRIPTION
Add default workspace recommendations for working on the YAPF project when using VSCode.

This picks up @EeyoreLee's https://marketplace.visualstudio.com/items?itemName=eeyore.yapf as YAPF support is being dropped by VSCode's built-in python extension.

This also uses @dangmai's https://marketplace.visualstudio.com/items?itemName=dangmai.workspace-default-settings to avoid messing with contributor's personal changes to settings.json.