### PR TITLE
Call unittest directly from tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,4 @@ envlist=py37,py38,py39,py310
 
 [testenv]
 commands=
-    python setup.py test
+    python -m unittest discover -p '*_test.py' yapftests/


### PR DESCRIPTION
Since moving to pyproject.toml tox began failing since the setup module had been removed. Instead we'll unittest directly from tox.