### PR TITLE
Add `Editor support.md`

### DIFF
--- a/EDITOR SUPPORT.md
+++ b/EDITOR SUPPORT.md
@@ -2,51 +2,57 @@
 
 YAPF is supported by multiple editors via community extensions or plugins.
 
-* [IntelliJ/PyCharm](#intellijpycharm)
-* [VSCode](#vscode)
+- [IntelliJ/PyCharm](#intellijpycharm)
+- [VSCode](#vscode)
 
 ## IntelliJ/PyCharm
+
 Use the `File Watchers` plugin to run YAPF against a file when you perform a save.
 
 1.  Install the File Watchers Plugin
 1.  Add the following to `.idea/watcherTasks.xml`. If you already have this file just add the `TaskOptions` section from below. This example uses Windows and a virtual environemtn, modify the `program` option as appropriate
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectTasksOptions">
-    <TaskOptions isEnabled="true">
-      <option name="arguments" value="-i $FilePathRelativeToProjectRoot$" />
-      <option name="checkSyntaxErrors" value="true" />
-      <option name="description" />
-      <option name="exitCodeBehavior" value="ERROR" />
-      <option name="fileExtension" value="py" />
-      <option name="immediateSync" value="true" />
-      <option name="name" value="yapf" />
-      <option name="output" value="" />
-      <option name="outputFilters">
-        <array />
-      </option>
-      <option name="outputFromStdout" value="false" />
-      <option name="program" value="$PROJECT_DIR$/.venv/Scripts/yapf.exe" />
-      <option name="runOnExternalChanges" value="true" />
-      <option name="scopeName" value="Project Files" />
-      <option name="trackOnlyRoot" value="false" />
-      <option name="workingDir" value="$Projectpath$" />
-      <envs />
-    </TaskOptions>
-  </component>
-</project>
-```
+    ```xml
+    <?xml version="1.0" encoding="UTF-8"?>
+    <project version="4">
+    <component name="ProjectTasksOptions">
+        <TaskOptions isEnabled="true">
+        <option name="arguments" value="-i $FilePathRelativeToProjectRoot$" />
+        <option name="checkSyntaxErrors" value="true" />
+        <option name="description" />
+        <option name="exitCodeBehavior" value="ERROR" />
+        <option name="fileExtension" value="py" />
+        <option name="immediateSync" value="true" />
+        <option name="name" value="yapf" />
+        <option name="output" value="" />
+        <option name="outputFilters">
+            <array />
+        </option>
+        <option name="outputFromStdout" value="false" />
+        <option name="program" value="$PROJECT_DIR$/.venv/Scripts/yapf.exe" />
+        <option name="runOnExternalChanges" value="true" />
+        <option name="scopeName" value="Project Files" />
+        <option name="trackOnlyRoot" value="false" />
+        <option name="workingDir" value="$Projectpath$" />
+        <envs />
+        </TaskOptions>
+    </component>
+    </project>
+    ```
 
 ## VSCode
 
-1. Install the [yapf](https://marketplace.visualstudio.com/items?itemName=eeyore.yapf) plugin.
-1. Install the yapf package since this extension didn't include it.
+VSCode has deprecated support for YAPF in its official Python extension [in favor of dedicated formatter extensions](https://github.com/microsoft/vscode-python/wiki/Migration-to-Python-Tools-Extensions).
+
+1. Install EeyoreLee's [yapf](https://marketplace.visualstudio.com/items?itemName=eeyore.yapf) extension.
+1. Install the yapf package from pip.
+   ```
+   pip install yapf
+   ```
 1. Setup vscode settings by editting settings.json in User scope or Workspace scope in following: Example of settings
-```jsonc
-  "[python]": {
-    "editor.formatOnSaveMode": "file",
-    "editor.formatOnSave": true,
-    "editor.defaultFormatter": "eeyore.yapf"  # choose this extension
-  },
-```
+   ```jsonc
+   "[python]": {
+       "editor.formatOnSaveMode": "file",
+       "editor.formatOnSave": true,
+       "editor.defaultFormatter": "eeyore.yapf"  # choose this extension
+   },
+   ```

--- a/EDITOR SUPPORT.md
+++ b/EDITOR SUPPORT.md
@@ -72,7 +72,7 @@ VSCode has deprecated support for YAPF in its official Python extension [in favo
    ```
    pip install yapf
    ```
-1. Setup vscode settings by editting settings.json in User scope or Workspace scope in following: Example of settings
+1. Add the following to VSCode's `settings.json`:
    ```jsonc
    "[python]": {
        "editor.formatOnSaveMode": "file",

--- a/EDITOR SUPPORT.md
+++ b/EDITOR SUPPORT.md
@@ -16,24 +16,24 @@ Use the `File Watchers` plugin to run YAPF against a file when you perform a sav
     <project version="4">
     <component name="ProjectTasksOptions">
         <TaskOptions isEnabled="true">
-        <option name="arguments" value="-i $FilePathRelativeToProjectRoot$" />
-        <option name="checkSyntaxErrors" value="true" />
-        <option name="description" />
-        <option name="exitCodeBehavior" value="ERROR" />
-        <option name="fileExtension" value="py" />
-        <option name="immediateSync" value="true" />
-        <option name="name" value="yapf" />
-        <option name="output" value="" />
-        <option name="outputFilters">
-            <array />
-        </option>
-        <option name="outputFromStdout" value="false" />
-        <option name="program" value="$PROJECT_DIR$/.venv/Scripts/yapf.exe" />
-        <option name="runOnExternalChanges" value="true" />
-        <option name="scopeName" value="Project Files" />
-        <option name="trackOnlyRoot" value="false" />
-        <option name="workingDir" value="$Projectpath$" />
-        <envs />
+            <option name="arguments" value="-i $FilePathRelativeToProjectRoot$" />
+            <option name="checkSyntaxErrors" value="true" />
+            <option name="description" />
+            <option name="exitCodeBehavior" value="ERROR" />
+            <option name="fileExtension" value="py" />
+            <option name="immediateSync" value="true" />
+            <option name="name" value="yapf" />
+            <option name="output" value="" />
+            <option name="outputFilters">
+                <array />
+            </option>
+            <option name="outputFromStdout" value="false" />
+            <option name="program" value="$PROJECT_DIR$/.venv/Scripts/yapf.exe" />
+            <option name="runOnExternalChanges" value="true" />
+            <option name="scopeName" value="Project Files" />
+            <option name="trackOnlyRoot" value="false" />
+            <option name="workingDir" value="$Projectpath$" />
+            <envs />
         </TaskOptions>
     </component>
     </project>

--- a/EDITOR SUPPORT.md
+++ b/EDITOR SUPPORT.md
@@ -10,7 +10,7 @@ YAPF is supported by multiple editors via community extensions or plugins.
 Use the `File Watchers` plugin to run YAPF against a file when you perform a save.
 
 1.  Install the File Watchers Plugin
-1.  Add the following to `.idea/watcherTasks.xml`. If you already have this file just add the `TaskOptions` section from below. This example uses Windows and a virtual environemtn, modify the `program` option as appropriate
+1.  Add the following `.idea/watcherTasks.xml` to your project. If you already have this file just add the `TaskOptions` section from below. This example uses Windows and a virtual environemtn, modify the `program` option as appropriate
     ```xml
     <?xml version="1.0" encoding="UTF-8"?>
     <project version="4">

--- a/EDITOR SUPPORT.md
+++ b/EDITOR SUPPORT.md
@@ -3,6 +3,7 @@
 YAPF is supported by multiple editors via community extensions or plugins.
 
 - [IntelliJ/PyCharm](#intellijpycharm)
+- [IPython](#ipython)
 - [VSCode](#vscode)
 
 ## IntelliJ/PyCharm
@@ -38,6 +39,29 @@ Use the `File Watchers` plugin to run YAPF against a file when you perform a sav
         </component>
     </project>
     ```
+
+## IPython
+
+IPython supports formatting lines automatically when you press the `<Enter>` button to submit the current code block.
+
+Make sure that the YAPF module is available to the IPython runtime:
+
+```shell
+pip install ipython yapf
+```
+
+pipx example:
+
+```shell
+pipx install ipython
+pipx inject ipython yapf
+```
+
+Add following to `~/.ipython/profile_default/ipython_config.py`:
+
+```python
+c.TerminalInteractiveShell.autoformatter = 'yapf'
+```
 
 ## VSCode
 

--- a/EDITOR SUPPORT.md
+++ b/EDITOR SUPPORT.md
@@ -1,0 +1,52 @@
+# Using YAPF with your editor
+
+YAPF is supported by multiple editors via community extensions or plugins.
+
+* [IntelliJ/PyCharm](#intellijpycharm)
+* [VSCode](#vscode)
+
+## IntelliJ/PyCharm
+Use the `File Watchers` plugin to run YAPF against a file when you perform a save.
+
+1.  Install the File Watchers Plugin
+1.  Add the following to `.idea/watcherTasks.xml`. If you already have this file just add the `TaskOptions` section from below. This example uses Windows and a virtual environemtn, modify the `program` option as appropriate
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectTasksOptions">
+    <TaskOptions isEnabled="true">
+      <option name="arguments" value="-i $FilePathRelativeToProjectRoot$" />
+      <option name="checkSyntaxErrors" value="true" />
+      <option name="description" />
+      <option name="exitCodeBehavior" value="ERROR" />
+      <option name="fileExtension" value="py" />
+      <option name="immediateSync" value="true" />
+      <option name="name" value="yapf" />
+      <option name="output" value="" />
+      <option name="outputFilters">
+        <array />
+      </option>
+      <option name="outputFromStdout" value="false" />
+      <option name="program" value="$PROJECT_DIR$/.venv/Scripts/yapf.exe" />
+      <option name="runOnExternalChanges" value="true" />
+      <option name="scopeName" value="Project Files" />
+      <option name="trackOnlyRoot" value="false" />
+      <option name="workingDir" value="$Projectpath$" />
+      <envs />
+    </TaskOptions>
+  </component>
+</project>
+```
+
+## VSCode
+
+1. Install the [yapf](https://marketplace.visualstudio.com/items?itemName=eeyore.yapf) plugin.
+1. Install the yapf package since this extension didn't include it.
+1. Setup vscode settings by editting settings.json in User scope or Workspace scope in following: Example of settings
+```jsonc
+  "[python]": {
+    "editor.formatOnSaveMode": "file",
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "eeyore.yapf"  # choose this extension
+  },
+```

--- a/EDITOR SUPPORT.md
+++ b/EDITOR SUPPORT.md
@@ -9,7 +9,7 @@ YAPF is supported by multiple editors via community extensions or plugins.
 
 Use the `File Watchers` plugin to run YAPF against a file when you perform a save.
 
-1.  Install the File Watchers Plugin
+1.  Install the [File Watchers](https://www.jetbrains.com/help/idea/using-file-watchers.html) Plugin
 1.  Add the following `.idea/watcherTasks.xml` to your project. If you already have this file just add the `TaskOptions` section from below. This example uses Windows and a virtual environemtn, modify the `program` option as appropriate
     ```xml
     <?xml version="1.0" encoding="UTF-8"?>

--- a/EDITOR SUPPORT.md
+++ b/EDITOR SUPPORT.md
@@ -10,32 +10,32 @@ YAPF is supported by multiple editors via community extensions or plugins.
 Use the `File Watchers` plugin to run YAPF against a file when you perform a save.
 
 1.  Install the [File Watchers](https://www.jetbrains.com/help/idea/using-file-watchers.html) Plugin
-1.  Add the following `.idea/watcherTasks.xml` to your project. If you already have this file just add the `TaskOptions` section from below. This example uses Windows and a virtual environemtn, modify the `program` option as appropriate
+1.  Add the following `.idea/watcherTasks.xml` to your project. If you already have this file just add the `TaskOptions` section from below. This example uses Windows and a virtual environment, modify the `program` option as appropriate.
     ```xml
     <?xml version="1.0" encoding="UTF-8"?>
     <project version="4">
-    <component name="ProjectTasksOptions">
-        <TaskOptions isEnabled="true">
-            <option name="arguments" value="-i $FilePathRelativeToProjectRoot$" />
-            <option name="checkSyntaxErrors" value="true" />
-            <option name="description" />
-            <option name="exitCodeBehavior" value="ERROR" />
-            <option name="fileExtension" value="py" />
-            <option name="immediateSync" value="true" />
-            <option name="name" value="yapf" />
-            <option name="output" value="" />
-            <option name="outputFilters">
-                <array />
-            </option>
-            <option name="outputFromStdout" value="false" />
-            <option name="program" value="$PROJECT_DIR$/.venv/Scripts/yapf.exe" />
-            <option name="runOnExternalChanges" value="true" />
-            <option name="scopeName" value="Project Files" />
-            <option name="trackOnlyRoot" value="false" />
-            <option name="workingDir" value="$Projectpath$" />
-            <envs />
-        </TaskOptions>
-    </component>
+        <component name="ProjectTasksOptions">
+            <TaskOptions isEnabled="true">
+                <option name="arguments" value="-i $FilePathRelativeToProjectRoot$" />
+                <option name="checkSyntaxErrors" value="true" />
+                <option name="description" />
+                <option name="exitCodeBehavior" value="ERROR" />
+                <option name="fileExtension" value="py" />
+                <option name="immediateSync" value="true" />
+                <option name="name" value="yapf" />
+                <option name="output" value="" />
+                <option name="outputFilters">
+                    <array />
+                </option>
+                <option name="outputFromStdout" value="false" />
+                <option name="program" value="$PROJECT_DIR$/.venv/Scripts/yapf.exe" />
+                <option name="runOnExternalChanges" value="true" />
+                <option name="scopeName" value="Project Files" />
+                <option name="trackOnlyRoot" value="false" />
+                <option name="workingDir" value="$Projectpath$" />
+                <envs />
+            </TaskOptions>
+        </component>
     </project>
     ```
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ optional arguments:
   -vv, --verbose        print out file names while processing
 ```
 
+### Using YAPF within your favorite editor
+YAPF is supported by multiple editors via community extensions or plugins. See [Editor Support](EDITOR%20SUPPORT.md) for more info.
+
 ### Return Codes
 
 Normally YAPF returns zero on successful program termination and non-zero


### PR DESCRIPTION
Closes #1124 and #1125

Add instructions for common editors.

I'd like this to include at a minimum:
- [X] IntelliJ
- [X] IPython
- [X] PyCharm
- [x] VSCode

Others are welcome.

