### PR TITLE
Add additional project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,11 @@ yapf = "yapf:run_main"
 yapf-diff = "yapf_third_party.yapf_diff.yapf_diff:main"
 
 [project.urls]
-url = 'https://github.com/google/yapf'
-changelog = "https://github.com/google/yapf/blob/main/CHANGELOG.md"
+# https://daniel.feldroy.com/posts/2023-08-pypi-project-urls-cheatsheet
+Home = 'https://github.com/google/yapf'
+Changelog = 'https://github.com/google/yapf/blob/main/CHANGELOG.md'
+Docs = 'https://github.com/google/yapf/blob/main/README.md#yapf'
+Issues = 'https://github.com/google/yapf/issues'
 
 [tool.distutils.bdist_wheel]
 python_tag = "py3"


### PR DESCRIPTION
Using https://daniel.feldroy.com/posts/2023-08-pypi-project-urls-cheatsheet and https://github.com/pypi/warehouse/blob/70eac9796fa1eae24741525688a112586eab9010/warehouse/templates/packaging/detail.html#L20-L62 as a reference add additional project URLs.