### PR TITLE
#1131 fix for  #1121  did not fix vscode behavior on ubuntu

### DIFF
--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -12,6 +12,9 @@
         "editor.wordBasedSuggestions": false,
         "files.trimTrailingWhitespace": true,
     },
+    "python.analysis.extraPaths": [
+        "./third_party"
+    ],
     "python.analysis.typeCheckingMode": "basic",
     "python.languageServer": "Pylance",
     "files.exclude": {

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ requires =
     tox<4
     tox-pyenv
     tox-wheel
+    pre-commit
 envlist = py37,py38,py39,py310,py311
 # tox-wheel alias for `wheel_pep517 = true`
 isolated_build = True

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ requires =
     tox<4
     tox-pyenv
     tox-wheel
-    pre-commit
 envlist = py37,py38,py39,py310,py311
 # tox-wheel alias for `wheel_pep517 = true`
 isolated_build = True


### PR DESCRIPTION
So while migrating to pyproject.toml fixed editable installation behavior on Ubuntu, Pylance was still unable to figure out imports as vscode does not understand the import script `.venv/lib/python3.10/site-packages/__editable___yapf_0_40_2_finder.py` created by an editable install triggered by `pip install -m venv .venv`

Using https://microsoft.github.io/pyright/#/import-resolution?id=setuptools suggestions of compat and strict mode did not resolve issues either.

So instead I revert to manually adding third_party to the `python.analysis.extraPaths` setting in settings.json