### PR TITLE
copy globals()

### DIFF
--- a/third_party/yapf_third_party/_ylib2to3/pgen2/token.py
+++ b/third_party/yapf_third_party/_ylib2to3/pgen2/token.py
@@ -70,7 +70,7 @@ NT_OFFSET = 256
 # --end constants--
 
 tok_name = {}
-for _name, _value in list(globals().items()):
+for _name, _value in list(globals().copy().items()):
   if isinstance(_value, int):
     tok_name[_value] = _name
 

--- a/third_party/yapf_third_party/_ylib2to3/pgen2/token.py
+++ b/third_party/yapf_third_party/_ylib2to3/pgen2/token.py
@@ -69,10 +69,11 @@ N_TOKENS = 60
 NT_OFFSET = 256
 # --end constants--
 
-tok_name = {}
-for _name, _value in list(globals().copy().items()):
-  if isinstance(_value, int):
-    tok_name[_value] = _name
+tok_name = {
+    _value: _name
+    for _name, _value in globals().copy().items()
+    if isinstance(_value, int)
+}
 
 
 def ISTERMINAL(x):


### PR DESCRIPTION
Fixes #1118. Use a copy of globals() rather than a direct reference. This did not appear to impact the time of tests.