### PR TITLE
Move “use within your favorite editor” to an earlier section in READM…

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ possible to run:
 $ PYTHONPATH=DIR python DIR/yapf [options] ...
 ```
 
+## Using YAPF within your favorite editor
+YAPF is supported by multiple editors via community extensions or plugins. See [Editor Support](EDITOR%20SUPPORT.md) for more info.
 
 ## Required Python versions
 
@@ -92,8 +94,6 @@ optional arguments:
   -vv, --verbose        print out file names while processing
 ```
 
-### Using YAPF within your favorite editor
-YAPF is supported by multiple editors via community extensions or plugins. See [Editor Support](EDITOR%20SUPPORT.md) for more info.
 
 ### Return Codes
 


### PR DESCRIPTION
This section’s current place between Usage and Return codes doesn’t make much sense.

Better off front loading as early as reasonable usage docs on YAPF editor integrations.