### PR TITLE
using ylib2to3 means we can test <=py311 on any python version supported by YAPF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.11"]  # no particular need for 3.9 or 3.10
+        python-version: ["3.7", "3.11", "3.12"]  # no particular need for 3.9 or 3.10
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac  # v4.0.0

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -22,9 +22,6 @@ from yapf.yapflib import style
 
 from yapftests import yapf_test_helper
 
-PY38 = sys.version_info[0] >= 3 and sys.version_info[1] >= 8
-PY310 = sys.version_info[0] >= 3 and sys.version_info[1] >= 10
-
 
 class BasicReformatterTest(yapf_test_helper.YAPFTest):
 
@@ -3217,7 +3214,6 @@ xxxxxxxxxxx, yyyyyyyyyyyy, vvvvvvvvv)
     finally:
       style.SetGlobalStyle(style.CreateYapfStyle())
 
-  @unittest.skipUnless(PY38, 'Requires Python 3.8')
   def testWalrus(self):
     unformatted_code = textwrap.dedent("""\
         if (x  :=  len([1]*1000)>100):
@@ -3230,7 +3226,6 @@ xxxxxxxxxxx, yyyyyyyyyyyy, vvvvvvvvv)
     llines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
     self.assertCodeEqual(expected, reformatter.Reformat(llines))
 
-  @unittest.skipUnless(PY310, 'Requires Python 3.10')
   def testStructuredPatternMatching(self):
     unformatted_code = textwrap.dedent("""\
         match command.split():
@@ -3249,7 +3244,6 @@ xxxxxxxxxxx, yyyyyyyyyyyy, vvvvvvvvv)
     llines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
     self.assertCodeEqual(expected, reformatter.Reformat(llines))
 
-  @unittest.skipUnless(PY310, 'Requires Python 3.10')
   def testParenthesizedContextManagers(self):
     unformatted_code = textwrap.dedent("""\
         with (cert_authority.cert_pem.tempfile() as ca_temp_path, patch.object(os, 'environ', os.environ | {'REQUESTS_CA_BUNDLE': ca_temp_path}),):


### PR DESCRIPTION
This may supersede #1132.

Since we're using ylib2to3 instead of lib2to3 this means we can test <=py311 on any python version supported by YAPF.


[] remove language in Readme that says YAPF must run as the same version of Python as the code you're  formatting.