### PR TITLE
Update README.md - cleanup for #1162

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,6 @@ YAPF is supported by multiple editors via community extensions or plugins. See [
 
 YAPF supports Python 3.7+.
 
-> **Note**
-> YAPF requires the code it formats to be valid Python for the version YAPF
-> itself runs under.
-
 
 ## Usage
 


### PR DESCRIPTION
Cleanup for #1162 - YAPF running under Python 3.7 against 3.11 code will work now that it's based on ylib2to3 instead of lib2to3.