### PR TITLE
Add new DISABLE_SPLIT_LIST_WITH_COMMENT flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Remove dependency on importlib-metadata
 - Remove dependency on tomli when using >= py311
 ### Added
+
+#### New `DISABLE_SPLIT_LIST_WITH_COMMENT` flag
 - `DISABLE_SPLIT_LIST_WITH_COMMENT` is a new knob that changes the
   behavior of splitting a list when a comment is present inside the list.
 
@@ -14,19 +16,60 @@
   containing a trailing comma: Each element goes on its own line (unless
   `DISABLE_ENDING_COMMA_HEURISTIC` is true).
 
-  Now, if `DISABLE_SPLIT_LIST_WITH_COMMENT` is true, we do not split every
-  element of the list onto a new line just because there's a comment somewhere
-  in the list.
+  This new flag allows you to control the behavior of a list with a comment
+  *separately* from the behavior when the list contains a trailing comma.
 
   This mirrors the behavior of clang-format, and is useful for e.g. forming
   "logical groups" of elements in a list.
 
-  Note: Upgrading will result in a behavioral change if you have
-  `DISABLE_ENDING_COMMA_HEURISTIC` in your config.  Before this version, this
-  flag caused us not to split lists with a trailing comma *and* lists that
-  contain comments.  Now, if you set only that flag, we *will* split lists
-  that contain comments.  Set the new `DISABLE_SPLIT_LIST_WITH_COMMENT` flag to
-  true to preserve the old behavior.
+  Without this flag:
+
+  ```
+  [
+    a,
+    b,  #
+    c
+  ]
+  ```
+
+  With this flag:
+
+  ```
+  [
+    a, b,  #
+    c
+  ]
+  ```
+
+  Before we had one flag that controlled two behaviors.
+
+    - `DISABLE_ENDING_COMMA_HEURISTIC=false` (default):
+      - Split a list that has a trailing comma.
+      - Split a list that contains a comment.
+    - `DISABLE_ENDING_COMMA_HEURISTIC=true`:
+      - Don't split on trailing comma.
+      - Don't split on comment.
+
+  Now we have two flags.
+
+    - `DISABLE_ENDING_COMMA_HEURISTIC=false` and `DISABLE_SPLIT_LIST_WITH_COMMENT=false` (default):
+      - Split a list that has a trailing comma.
+      - Split a list that contains a comment.
+      Behavior is unchanged from the default before.
+    - `DISABLE_ENDING_COMMA_HEURISTIC=true` and `DISABLE_SPLIT_LIST_WITH_COMMENT=false` :
+      - Don't split on trailing comma.
+      - Do split on comment.  **This is a change in behavior from before.**
+    - `DISABLE_ENDING_COMMA_HEURISTIC=false` and `DISABLE_SPLIT_LIST_WITH_COMMENT=true` :
+      - Split on trailing comma.
+      - Don't split on comment.
+    - `DISABLE_ENDING_COMMA_HEURISTIC=true` and `DISABLE_SPLIT_LIST_WITH_COMMENT=true` :
+      - Don't split on trailing comma.
+      - Don't split on comment.
+      **You used to get this behavior just by setting one flag, but now you have to set both.**
+
+  Note the behavioral change above; if you set
+  `DISABLE_ENDING_COMMA_HEURISTIC=true` and want to keep the old behavior, you
+  now also need to set `DISABLE_SPLIT_LIST_WITH_COMMENT=true`.
 
 ### Fixed
 - Fix SPLIT_ARGUMENTS_WHEN_COMMA_TERMINATED for one-item named argument lists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@
 ### Changes
 - Remove dependency on importlib-metadata
 - Remove dependency on tomli when using >= py311
+### Added
+- `DISABLE_SPLIT_LIST_WITH_COMMENT` is a new knob that changes the
+  behavior of splitting a list when a comment is present inside the list.
+
+  Before, we split a list containing a comment just like we split a list
+  containing a trailing comma: Each element goes on its own line (unless
+  `DISABLE_ENDING_COMMA_HEURISTIC` is true).
+
+  Now, if `DISABLE_SPLIT_LIST_WITH_COMMENT` is true, we do not split every
+  element of the list onto a new line just because there's a comment somewhere
+  in the list.
+
+  This mirrors the behavior of clang-format, and is useful for e.g. forming
+  "logical groups" of elements in a list.
+
+  Note: Upgrading will result in a behavioral change if you have
+  `DISABLE_ENDING_COMMA_HEURISTIC` in your config.  Before this version, this
+  flag caused us not to split lists with a trailing comma *and* lists that
+  contain comments.  Now, if you set only that flag, we *will* split lists
+  that contain comments.  Set the new `DISABLE_SPLIT_LIST_WITH_COMMENT` flag to
+  true to preserve the old behavior.
+
 ### Fixed
 - Fix SPLIT_ARGUMENTS_WHEN_COMMA_TERMINATED for one-item named argument lists
   by taking precedence over SPLIT_BEFORE_NAMED_ASSIGNS.

--- a/README.md
+++ b/README.md
@@ -512,8 +512,15 @@ optional arguments:
 
 >    Disable the heuristic which places each list element on a separate line if
 >    the list is comma-terminated.
+>
+>    Note: The behavior of this flag changed in v0.40.3.  Before, if this flag
+>    was true, we would split lists that contained a trailing comma or a
+>    comment.  Now, we have a separate flag, `DISABLE_SPLIT_LIST_WITH_COMMENT`,
+>    that controls splitting when a list contains a comment.  To get the old
+>    behavior, set both flags to true.  More information in
+>    [CHANGELOG.md](CHANGELOG.md#new-disable_split_list_with_comment-flag).
 
-#### `DISABLE_DISABLE_SPLIT_LIST_WITH_COMMENT`
+#### `DISABLE_DISABLE_SPLIT_LIST_WITH_COMMENT` (new in 0.40.3)
 
 >    Don't put every element on a new line within a list that contains
 >    interstitial comments.
@@ -537,8 +544,9 @@ optional arguments:
 >    ]
 >    ```
 >
->    This is useful for forming "logical groups" of elements in a list.  It also
->    works in function declarations.
+>    This mirrors the behavior of clang-format and is useful for forming
+>    "logical groups" of elements in a list.  It also works in function
+>    declarations.
 
 #### `EACH_DICT_ENTRY_ON_SEPARATE_LINE`
 

--- a/README.md
+++ b/README.md
@@ -513,6 +513,33 @@ optional arguments:
 >    Disable the heuristic which places each list element on a separate line if
 >    the list is comma-terminated.
 
+#### `DISABLE_DISABLE_SPLIT_LIST_WITH_COMMENT`
+
+>    Don't put every element on a new line within a list that contains
+>    interstitial comments.
+>
+>    Without this flag (default):
+>
+>    ```
+>    [
+>      a,
+>      b,  #
+>      c
+>    ]
+>    ```
+>
+>    With this flag:
+>
+>    ```
+>    [
+>      a, b,  #
+>      c
+>    ]
+>    ```
+>
+>    This is useful for forming "logical groups" of elements in a list.  It also
+>    works in function declarations.
+
 #### `EACH_DICT_ENTRY_ON_SEPARATE_LINE`
 
 >    Place each dictionary entry onto its own line.

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -180,6 +180,10 @@ _STYLE_HELP = dict(
       Disable the heuristic which places each list element on a separate line
       if the list is comma-terminated.
     """),
+    DISABLE_SPLIT_LIST_WITH_COMMENT=textwrap.dedent("""
+      Don't put every element on a new line within a list that contains
+      interstitial comments.
+    """),
     EACH_DICT_ENTRY_ON_SEPARATE_LINE=textwrap.dedent("""\
       Place each dictionary entry onto its own line.
     """),
@@ -483,6 +487,7 @@ def CreatePEP8Style():
       CONTINUATION_INDENT_WIDTH=4,
       DEDENT_CLOSING_BRACKETS=False,
       DISABLE_ENDING_COMMA_HEURISTIC=False,
+      DISABLE_SPLIT_LIST_WITH_COMMENT=False,
       EACH_DICT_ENTRY_ON_SEPARATE_LINE=True,
       FORCE_MULTILINE_DICT=False,
       I18N_COMMENT='',
@@ -671,6 +676,7 @@ _STYLE_OPTION_VALUE_CONVERTER = dict(
     CONTINUATION_INDENT_WIDTH=int,
     DEDENT_CLOSING_BRACKETS=_BoolConverter,
     DISABLE_ENDING_COMMA_HEURISTIC=_BoolConverter,
+    DISABLE_SPLIT_LIST_WITH_COMMENT=_BoolConverter,
     EACH_DICT_ENTRY_ON_SEPARATE_LINE=_BoolConverter,
     FORCE_MULTILINE_DICT=_BoolConverter,
     I18N_COMMENT=str,

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -179,6 +179,12 @@ _STYLE_HELP = dict(
     DISABLE_ENDING_COMMA_HEURISTIC=textwrap.dedent("""\
       Disable the heuristic which places each list element on a separate line
       if the list is comma-terminated.
+
+      Note: The behavior of this flag changed in v0.40.3.  Before, if this flag
+      was true, we would split lists that contained a trailing comma or a
+      comment.  Now, we have a separate flag, `DISABLE_SPLIT_LIT_WITH_COMMENT`,
+      that controls splitting when a list contains a comment.  To get the old
+      behavior, set both flags to true.  More information in CHANGELOG.md.
     """),
     DISABLE_SPLIT_LIST_WITH_COMMENT=textwrap.dedent("""
       Don't put every element on a new line within a list that contains

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -357,7 +357,6 @@ class BasicReformatterTest(yapf_test_helper.YAPFTest):
               c):
           pass
     """)
-    llines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
     try:
       style.SetGlobalStyle(
           style.CreateStyleFromConfig(

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -345,6 +345,30 @@ class BasicReformatterTest(yapf_test_helper.YAPFTest):
     llines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
     self.assertCodeEqual(expected_formatted_code, reformatter.Reformat(llines))
 
+  def testParamListWithTrailingComments(self):
+    unformatted_code = textwrap.dedent("""\
+        def f(a,
+              b, #
+              c):
+          pass
+    """)
+    expected_formatted_code = textwrap.dedent("""\
+        def f(a, b,  #
+              c):
+          pass
+    """)
+    llines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
+    try:
+      style.SetGlobalStyle(
+          style.CreateStyleFromConfig(
+              '{based_on_style: yapf,'
+              ' disable_split_list_with_comment: True}'))
+      llines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
+      self.assertCodeEqual(expected_formatted_code,
+                           reformatter.Reformat(llines))
+    finally:
+      style.SetGlobalStyle(style.CreateYapfStyle())
+
   def testBlankLinesBetweenTopLevelImportsAndVariables(self):
     unformatted_code = textwrap.dedent("""\
         import foo as bar


### PR DESCRIPTION
`DISABLE_SPLIT_LIST_WITH_COMMENT` is a new knob that changes the
behavior of splitting a list when a comment is present inside the list.

Before, we split a list containing a comment just like we split a list
containing a trailing comma: Each element goes on its own line (unless
`DISABLE_ENDING_COMMA_HEURISTIC` is true).

Now, if `DISABLE_SPLIT_LIST_WITH_COMMENT` is true, we do not split every
element of the list onto a new line just because there's a comment somewhere
in the list.

This mirrors the behavior of clang-format, and is useful for e.g. forming
"logical groups" of elements in a list.

Note: Upgrading will result in a behavioral change if you have
`DISABLE_ENDING_COMMA_HEURISTIC` in your config.  Before this version, this
flag caused us not to split lists with a trailing comma *and* lists that
contain comments.  Now, if you set only that flag, we *will* split lists
that contain comments.  Set the new `DISABLE_SPLIT_LIST_WITH_COMMENT` flag to
true to preserve the old behavior.
