### PR TITLE
Allow joining of case statements in `line_joiner.py`

### DIFF
--- a/yapf/yapflib/line_joiner.py
+++ b/yapf/yapflib/line_joiner.py
@@ -72,22 +72,22 @@ def CanMergeMultipleLines(lines, last_was_merged=False):
   if lines[0].last.total_length < limit:
     limit -= lines[0].last.total_length
 
-    if lines[0].first.value == 'if':
-      return _CanMergeLineIntoIfStatement(lines, limit)
+    if lines[0].first.value in {'if', 'case'}:
+      return _CanMergeLineIntoIfOrCaseStatement(lines, limit)
     if last_was_merged and lines[0].first.value in {'elif', 'else'}:
-      return _CanMergeLineIntoIfStatement(lines, limit)
+      return _CanMergeLineIntoIfOrCaseStatement(lines, limit)
 
   # TODO(morbo): Other control statements?
 
   return False
 
 
-def _CanMergeLineIntoIfStatement(lines, limit):
-  """Determine if we can merge a short if-then statement into one line.
+def _CanMergeLineIntoIfOrCaseStatement(lines, limit):
+  """Determine if we can merge a short if-then or case statement into one line.
 
-  Two lines of an if-then statement can be merged if they were that way in the
-  original source, fit on the line without going over the column limit, and are
-  considered "simple" statements --- typically statements like 'pass',
+  Two lines of an if-then or case statement can be merged if they were that way 
+  in the original source, fit on the line without going over the column limit, 
+  and are considered "simple" statements --- typically statements like 'pass',
   'continue', and 'break'.
 
   Arguments:


### PR DESCRIPTION
Allows for the same joining rules that govern if-then statements to be applied to simple case statements.

Examples
------

This will allow the common (at least in C switch-case blocks, from my experience) idiom of converting if-else-if chains into simple match-case statements, e.g.:

```python
match format:
    case 'l': return string.ljust(width)
    case 'c': return string.center(width)
    case 'r': return string.rjust(width)
```

Without the proposed changes, the block above would be formatted like this:


```python
match format:
    case 'l': 
        return string.ljust(width)
    case 'c': 
        return string.center(width)
    case 'r': 
        return string.rjust(width)
```

---

This is my first time contributing to any open source project, so bear with me. Thanks!