### PR TITLE
fix 2-space rule when SPACES_BEFORE_COMMENT is a list

### DIFF
--- a/yapf/yapflib/reformatter.py
+++ b/yapf/yapflib/reformatter.py
@@ -340,7 +340,7 @@ def _AlignTrailingComments(final_lines):
             break
 
         if aligned_col is None:
-          aligned_col = max_line_length
+          aligned_col = max_line_length + 1
 
         # Update the comment token values based on the aligned values
         for all_pc_line_lengths_index, pc_line_lengths in enumerate(


### PR DESCRIPTION
As readme says with `spaces_before_comment="15, 20"`,
```python
    1 + 1 # Adding values
    two + two # More adding

    longer_statement # This is a longer statement
    short # This is a shorter statement

    a_very_long_statement_that_extends_beyond_the_final_column # Comment
    short # This is a shorter statement
```
will be formatted as:
```python
    1 + 1          # Adding values <-- end of line comments in block aligned to col 15
    two + two      # More adding

    longer_statement    # This is a longer statement <-- end of line comments in block aligned to col 20
    short               # This is a shorter statement

    a_very_long_statement_that_extends_beyond_the_final_column  # Comment <-- the end of line comments are aligned based on the line length
    short                                                       # This is a shorter statement
```
But now the behavior of yapf is formatting it as
```python
    1 + 1          # Adding values <-- end of line comments in block aligned to col 15
    two + two      # More adding

    longer_statement    # This is a longer statement <-- end of line comments in block aligned to col 20
    short               # This is a shorter statement

    a_very_long_statement_that_extends_beyond_the_final_column # Comment <-- the end of line comments are aligned based on the line length
    short                                                      # This is a shorter statement
```
The last comment block is preceded by only one space. This condition is also mentioned in #675 
I think the bug is caused by the below code in yapf/yapflib/reformatter.py#336
```python
        # Calculate the aligned column value
        max_line_length += 2

        aligned_col = None
        for potential_col in tok.spaces_required_before:
          if potential_col > max_line_length:
            aligned_col = potential_col
            break

        if aligned_col is None:
          aligned_col = max_line_length
```
When a value is selected in the `spaces_before_comment` list, `aligned_col` will be exactly larger than `max_line_length`. But when no values are selected, `aligned_col` will be not larger than `max_line_length`. So I modified the later behavior to make them consistent.