### PR TITLE
pre-commit: Add hook for yapf-diff

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,3 +7,15 @@
   args: [-i] #inplace
   language: python
   types: [python]
+
+- id: yapf-diff
+  name: yapf-diff
+  description: "A formatter for Python files. (formats only changes included in commit)"
+  always_run: true
+  language: python
+  pass_filenames: false
+  stages: [pre-commit]
+  entry: |
+    bash -c "git diff -U0 --no-color --relative HEAD \
+                  | yapf-diff \
+                  | tee >(git apply --allow-empty -p0)"


### PR DESCRIPTION
This pull request adds a pre-commit hook for yapf-diff. The hook  executes yapf-diff whenever a commit is about to be made and applies the resulting diff. Additionally it displays the diff so that the changes could be easily reviewed manually. 