### PR TITLE
Add an explicit `flush` and `close` before `os.rename` to fix `EOFError: Ran out of input`

### DIFF
--- a/third_party/yapf_third_party/_ylib2to3/pgen2/grammar.py
+++ b/third_party/yapf_third_party/_ylib2to3/pgen2/grammar.py
@@ -111,6 +111,8 @@ class Grammar(object):
         dir=tempfile_dir,
         delete=False) as f:
       pickle.dump(self.__dict__, f.file, pickle.HIGHEST_PROTOCOL)
+      f.flush()
+      f.close()
       try:
         os.rename(f.name, filename)
       except OSError:


### PR DESCRIPTION
Even with this fix: https://github.com/google/yapf/pull/1243 `EOFError: Ran out of input` error is observed when using `yapf` with `pre-commit` on powerful multi-core systems.

Before I suggest this change to you, I tested it in our repository using a fork: https://github.com/intel/intel-xpu-backend-for-triton/pull/3324. For 5 days now I have not seen the error again, which gives me confidence to say that the change at least reduces the frequency of this problem, and at most solves it completely.

Hi @bwendling, could you review this change?