### PR TITLE
yapf will fail on Python >= 3.13 because lib2to3 was removed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.11", "3.12"]  # no particular need for 3.9 or 3.10
+        # Python >= 3.13 will fail with `ModuleNotFoundError: No module named 'lib2to3'`
+        # See: google/yapf#1258
+        python-version: ["3.8", "3.11", "3.12", "3.13"]  # no particular need for 3.9 or 3.10
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871  # v4.2.1


### PR DESCRIPTION
`lib2to3` has been removed from the standard library in Python 3.13.

Document the incompatibility and the need for:
* #1258