### PR TITLE
Consolidate dependabot updates to a single PR at a time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       include: "scope"
       prefix: "Actions"
     directory: "/"
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
     labels:
       - "enhancement"
     schedule:


### PR DESCRIPTION
There are currently [three open Dependabot pull requests for GitHub Actions](https://github.com/google/yapf/pulls/app%2Fdependabot).  It would probably be easier to review and merge these PRs if they were consolidated so there would be at most only one open Dependabot PR to review.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--