### PR TITLE
Support multiple blank lines between class methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,21 @@ optional arguments:
         pass
 ```
 
+#### `BLANK_LINES_BETWEEN_CLASS_DEFS`
+
+>    Sets the number of desired blank lines between methods inside
+>    class definitions. For example:
+
+```python
+    class Foo:
+        def method1():
+            pass
+                       # <------ multiple
+                       # <------ blank lines here
+        def method2():
+            pass
+```
+
 #### `BLANK_LINE_BEFORE_CLASS_DOCSTRING`
 
 >    Insert a blank line before a class-level docstring.

--- a/yapf/pytree/pytree_utils.py
+++ b/yapf/pytree/pytree_utils.py
@@ -332,3 +332,34 @@ def _PytreeNodeRepr(node):
 def IsCommentStatement(node):
   return (NodeName(node) == 'simple_stmt' and
           node.children[0].type == token.COMMENT)
+
+
+def AscendTo(node, target_names):
+  n = node
+  while n is not None and NodeName(n) not in target_names:
+    n = getattr(n, 'parent', None)
+  return n if n is not None and NodeName(n) in target_names else None
+
+
+def EnclosingFunc(node):
+  return node if NodeName(node) == 'funcdef' else AscendTo(node, {'funcdef'})
+
+
+def EnclosingClass(node):
+  return node if NodeName(node) == 'classdef' else AscendTo(node, {'classdef'})
+
+
+def IsFuncDef(node):
+  return node is not None and NodeName(node) == 'funcdef'
+
+
+def IsClassDef(node):
+  return node is not None and NodeName(node) == 'classdef'
+
+
+def DecoratedTarget(node, target_names=('funcdef', 'classdef')):
+  n = node
+  while n.next_sibling is not None and NodeName(n.next_sibling) == 'decorator':
+    n = n.next_sibling
+  cand = n.next_sibling
+  return cand if cand is not None and NodeName(cand) in target_names else None

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -115,6 +115,18 @@ _STYLE_HELP = dict(
           def method():
             pass
     """),
+    BLANK_LINES_BETWEEN_CLASS_DEFS=textwrap.dedent("""\
+      Sets the number of desired blank lines between methods inside
+      class definitions. For example:
+
+        class Foo:
+          def method1():
+            pass
+                           # <------ multiple
+                           # <------ blank lines
+          def method2():
+            pass
+    """),
     BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION=textwrap.dedent("""\
       Number of blank lines surrounding top-level function and class
       definitions.
@@ -486,6 +498,7 @@ def CreatePEP8Style():
       BLANK_LINE_BEFORE_MODULE_DOCSTRING=False,
       BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF=True,
       BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION=2,
+      BLANK_LINES_BETWEEN_CLASS_DEFS=1,
       BLANK_LINES_BETWEEN_TOP_LEVEL_IMPORTS_AND_VARIABLES=1,
       COALESCE_BRACKETS=False,
       COLUMN_LIMIT=79,
@@ -675,6 +688,7 @@ _STYLE_OPTION_VALUE_CONVERTER = dict(
     BLANK_LINE_BEFORE_MODULE_DOCSTRING=_BoolConverter,
     BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF=_BoolConverter,
     BLANK_LINES_AROUND_TOP_LEVEL_DEFINITION=int,
+    BLANK_LINES_BETWEEN_CLASS_DEFS=int,
     BLANK_LINES_BETWEEN_TOP_LEVEL_IMPORTS_AND_VARIABLES=int,
     COALESCE_BRACKETS=_BoolConverter,
     COLUMN_LIMIT=int,


### PR DESCRIPTION
Support arbitrary number of line breaks between class methods.

This update breaks the PEP8 style, but defaults to PEP8 of one linebreak.