### PR TITLE
omitting [style] breaks yapf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@
   by taking precedence over SPLIT_BEFORE_NAMED_ASSIGNS.
 - Fix SPLIT_ALL_COMMA_SEPARATED_VALUES and SPLIT_ALL_TOP_LEVEL_COMMA_SEPARATED_VALUES
   being too agressive for lambdas and unpacking.
+- Fix a crash (`TypeError: 'int' object is not subscriptable`) when a style
+  file is missing its `[style]` section header.
 
 ## [0.40.2] 2023-09-22
 ### Changes

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Python formatting style settings."""
 
+import configparser
 import os
 import re
 import sys
@@ -821,7 +822,12 @@ def _CreateConfigParserFromConfigFile(config_filename):
       return config
 
   with open(config_filename) as style_file:
-    config.read_file(style_file)
+    try:
+      config.read_file(style_file)
+    except configparser.MissingSectionHeaderError:
+      raise StyleConfigError(
+          'Unable to parse {0}: missing section header. Did you forget the '
+          '"[style]" header?'.format(config_filename))
 
     if config_filename.endswith(SETUP_CONFIG):
       if not config.has_section('yapf'):

--- a/yapftests/style_test.py
+++ b/yapftests/style_test.py
@@ -207,6 +207,15 @@ class StyleFromFileTest(yapf_test_helper.YAPFTest):
                                 'is not a valid style or file path'):
       style.CreateStyleFromConfig('/8822/xyznosuchfile')
 
+  def testErrorMissingSectionHeader(self):
+    cfg = textwrap.dedent("""\
+        indent_width=2
+    """)
+    with utils.TempFileContents(self.test_tmpdir, cfg) as filepath:
+      with self.assertRaisesRegex(style.StyleConfigError,
+                                  'missing section header'):
+        style.CreateStyleFromConfig(filepath)
+
   def testErrorNoStyleSection(self):
     cfg = textwrap.dedent("""\
         [s]


### PR DESCRIPTION
Fixes #1286.

## What changed
- `CHANGELOG.md`
- `yapf/yapflib/style.py`
- `yapftests/style_test.py`

## Verification
The project's own test suite was run before and after this change; it introduces no new test failures or lint violations.