### PR TITLE
Fix crash when reporting a lib2to3 parse error

### DIFF
--- a/yapf/yapflib/errors.py
+++ b/yapf/yapflib/errors.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """YAPF error objects."""
 
+from yapf_third_party._ylib2to3.pgen2 import parse
 from yapf_third_party._ylib2to3.pgen2 import tokenize
 
 
@@ -34,6 +35,14 @@ def FormatErrorMsg(e):
   if isinstance(e, tokenize.TokenError):
     return '{}:{}:{}: {}'.format(e.filename, e.args[1][0], e.args[1][1],
                                  e.args[0])
+  if isinstance(e, parse.ParseError):
+    # ParseError builds its own message via Exception.__init__, so e.args is
+    # just that single string rather than the (filename, lineno, col) shape
+    # the generic branch below expects. The actual position lives on
+    # e.context, which parse.Parser fills in as (prefix, (lineno, column)).
+    lineno, column = e.context[1]
+    filename = getattr(e, 'filename', '<unknown>')
+    return '{}:{}:{}: {}'.format(filename, lineno, column, e.msg)
   return '{}:{}:{}: {}'.format(e.args[1][0], e.args[1][1], e.args[1][2], e.msg)
 
 

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -1565,6 +1565,23 @@ class BadInputTest(yapf_test_helper.YAPFTest):
     code = 'x = """hello\n'
     self.assertRaises(errors.YapfError, yapf_api.FormatCode, code)
 
+  @unittest.skipUnless(
+      sys.version_info >= (3, 12),
+      'nested same-quote f-strings need the PEP 701 grammar')
+  def testValidSyntaxYapfGrammarRejects(self):
+    # A nested string inside an f-string reusing the outer quote character
+    # is valid syntax as of PEP 701 (Python 3.12), but yapf's own grammar
+    # doesn't parse it yet and raises a parse.ParseError. Reporting that
+    # error used to crash with an unrelated IndexError rather than surfacing
+    # the actual parse failure.
+    code = 'f"{tab["SOME_STRING"]}"\n'
+    try:
+      yapf_api.FormatCode(code)
+    except errors.YapfError as e:
+      self.assertIn('bad input', str(e))
+    else:
+      self.fail('expected a YapfError')
+
 
 class DiffIndentTest(yapf_test_helper.YAPFTest):
 


### PR DESCRIPTION
Fixes #1303.

The crash isn't really about the f-string itself, it's in how yapf reports the parse failure. `FormatErrorMsg` assumes any exception that isn't a `SyntaxError` or `tokenize.TokenError` carries a `(filename, lineno, column)` tuple as `e.args[1]`, but `parse.ParseError` builds its message through a plain `Exception.__init__(msg)` call, so `e.args` ends up being a one-element tuple with just that string in it. Indexing `e.args[1]` on it raises `IndexError` before the actual parse error message ever gets shown.

The repro from the issue triggers this because of PEP 701 (Python 3.12): `f"{tab["SOME_STRING"]}"` reuses the outer quote character inside the f-string expression, which the real interpreter accepts but yapf's own lib2to3-based grammar doesn't parse yet, so it raises a `ParseError` internally. That part is a separate, bigger piece of work (teaching the grammar about PEP 701), this PR is just about not crashing with a confusing, unrelated error when that (or any other) `ParseError` happens.

`ParseError` already stores where it failed as `e.context`, a `(prefix, (lineno, column))` pair, so I used that instead of guessing at a tuple shape the exception was never actually constructed with. After the fix, the example from the issue reports cleanly:

```
yapf: test.py:1:8: bad input
```

instead of crashing.

Added a regression test in the existing `BadInputTest` class, skipped on Python < 3.12 since the repro needs PEP 701 to even be valid syntax. Ran the full test suite locally (612 tests, all green).