### PR TITLE
Stop treating % as a template in style option values

### DIFF
--- a/yapf/yapflib/errors.py
+++ b/yapf/yapflib/errors.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """YAPF error objects."""
 
+from yapf_third_party._ylib2to3.pgen2 import parse
 from yapf_third_party._ylib2to3.pgen2 import tokenize
 
 
@@ -34,7 +35,13 @@ def FormatErrorMsg(e):
   if isinstance(e, tokenize.TokenError):
     return '{}:{}:{}: {}'.format(e.filename, e.args[1][0], e.args[1][1],
                                  e.args[0])
-  return '{}:{}:{}: {}'.format(e.args[1][0], e.args[1][1], e.args[1][2], e.msg)
+  if isinstance(e, parse.ParseError):
+    # The parser raises this for input it can't handle, e.g. valid Python that
+    # is newer than the vendored grammar. Its .context is a (prefix, (line,
+    # column)) pair rather than a plain offset like SyntaxError.
+    return '{}:{}:{}: {}'.format(e.filename, e.context[1][0], e.context[1][1],
+                                 e.msg)
+  return str(e)
 
 
 class YapfError(Exception):

--- a/yapf/yapflib/style.py
+++ b/yapf/yapflib/style.py
@@ -776,7 +776,7 @@ def CreateStyleFromConfig(style_config):
 
 
 def _CreateConfigParserFromConfigDict(config_dict):
-  config = ConfigParser()
+  config = ConfigParser(interpolation=None)
   config.add_section('style')
   for key, value in config_dict.items():
     config.set('style', key, str(value))
@@ -788,7 +788,7 @@ def _CreateConfigParserFromConfigString(config_string):
   if config_string[0] != '{' or config_string[-1] != '}':
     raise StyleConfigError(
         "Invalid style dict syntax: '{}'.".format(config_string))
-  config = ConfigParser()
+  config = ConfigParser(interpolation=None)
   config.add_section('style')
   for key, value, _ in re.findall(
       r'([a-zA-Z0-9_]+)\s*[:=]\s*'
@@ -806,7 +806,7 @@ def _CreateConfigParserFromConfigFile(config_filename):
     # Provide a more meaningful error here.
     raise StyleConfigError(
         '"{0}" is not a valid style or file path'.format(config_filename))
-  config = ConfigParser()
+  config = ConfigParser(interpolation=None)
 
   if config_filename.endswith(PYPROJECT_TOML):
     with open(config_filename, 'rb') as style_file:

--- a/yapftests/reformatter_style_config_test.py
+++ b/yapftests/reformatter_style_config_test.py
@@ -78,6 +78,25 @@ class TestsForStyleConfig(yapf_test_helper.YAPFTest):
       style.SetGlobalStyle(style.CreatePEP8Style())
       style.DEFAULT_STYLE = self.current_style
 
+  def testOperatorNoSpaceModuloStyle(self):
+    try:
+      cfg = style.CreateStyleFromConfig(
+          '{based_on_style: pep8,'
+          ' NO_SPACES_AROUND_SELECTED_BINARY_OPERATORS: "%"}')
+      style.SetGlobalStyle(cfg)
+      unformatted_code = textwrap.dedent("""\
+          a = 1 % 2
+      """)
+      expected_formatted_code = textwrap.dedent("""\
+          a = 1%2
+      """)
+      llines = yapf_test_helper.ParseAndUnwrap(unformatted_code)
+      self.assertCodeEqual(expected_formatted_code,
+                           reformatter.Reformat(llines))
+    finally:
+      style.SetGlobalStyle(style.CreatePEP8Style())
+      style.DEFAULT_STYLE = self.current_style
+
   def testOperatorPrecedenceStyle(self):
     try:
       pep8_with_precedence = style.CreatePEP8Style()

--- a/yapftests/style_test.py
+++ b/yapftests/style_test.py
@@ -202,6 +202,17 @@ class StyleFromFileTest(yapf_test_helper.YAPFTest):
       self.assertTrue(_LooksLikePEP8Style(cfg))
       self.assertEqual(cfg['I18N_FUNCTION_CALL'], ['N_', 'V_', 'T_'])
 
+  def testStringSetOptionValueWithPercent(self):
+    cfg = textwrap.dedent("""\
+        [style]
+        based_on_style = pep8
+        NO_SPACES_AROUND_SELECTED_BINARY_OPERATORS = "%"
+    """)
+    with utils.TempFileContents(self.test_tmpdir, cfg) as filepath:
+      cfg = style.CreateStyleFromConfig(filepath)
+      self.assertTrue(_LooksLikePEP8Style(cfg))
+      self.assertEqual(cfg['NO_SPACES_AROUND_SELECTED_BINARY_OPERATORS'], {'%'})
+
   def testErrorNoStyleFile(self):
     with self.assertRaisesRegex(style.StyleConfigError,
                                 'is not a valid style or file path'):
@@ -312,6 +323,12 @@ class StyleFromCommandLine(yapf_test_helper.YAPFTest):
                            style.CreateStyleFromConfig, '{INDENT_WIDTH: FOUR}')
     self.assertRaisesRegex(style.StyleConfigError, 'Invalid style dict',
                            style.CreateStyleFromConfig, '{based_on_style: pep8')
+
+  def testOperatorSetOptionWithPercent(self):
+    cfg = style.CreateStyleFromConfig(
+        '{based_on_style: pep8,'
+        ' NO_SPACES_AROUND_SELECTED_BINARY_OPERATORS: "%"}')
+    self.assertEqual(cfg['NO_SPACES_AROUND_SELECTED_BINARY_OPERATORS'], {'%'})
 
 
 class StyleHelp(yapf_test_helper.YAPFTest):

--- a/yapftests/yapf_test.py
+++ b/yapftests/yapf_test.py
@@ -1565,6 +1565,14 @@ class BadInputTest(yapf_test_helper.YAPFTest):
     code = 'x = """hello\n'
     self.assertRaises(errors.YapfError, yapf_api.FormatCode, code)
 
+  def testNewerSyntaxRaisesCleanError(self):
+    # These are valid Python 3.12+ that the vendored grammar doesn't handle
+    # yet. The parse failure should be reported as a YapfError, not crash with
+    # an IndexError while building the message.
+    for code in ('print(f"foo -> {os.path.join("bar", "baz")}")\n',
+                 'type Data = dict[str, Any]\n'):
+      self.assertRaises(errors.YapfError, yapf_api.FormatCode, code)
+
 
 class DiffIndentTest(yapf_test_helper.YAPFTest):
 


### PR DESCRIPTION
Two small fixes I ran into while messing with style config and parse-error handling.

1. A style file with `NO_SPACES_AROUND_SELECTED_BINARY_OPERATORS = "%"` made yapf blow up before it formatted anything. ConfigParser treats `%` as an interpolation marker, but style option values are never templates. I disabled interpolation for the parsers built from style dicts, `--style` strings, and style files. With that, the setting behaves as expected: `a = 1 % 2` becomes `a = 1%2`. Fixes #1187.

2. When yapf hit valid-but-newer Python (3.12+ f-strings reusing the quote, `type X = ...` aliases), it crashed again while trying to build the error message, ending in `IndexError: tuple index out of range`. FormatErrorMsg was assuming an exception shape that the vendored ParseError doesn't have. It now reads the line/column off ParseError.context and falls back to str(e) for anything else, so you get a clean `yapf: <file>:1:36: bad input` instead of a traceback. The code in those issues (#1303, #1215, #1250, #1256, #1290) still won't be formatted until the grammar learns the new syntax, but at least the error is honest now.

Added regression tests for both paths; the full yapftests suite passes.