### PR TITLE
fix(reformatter): ensure idempotent formatting for dictionary values with line continuation

### DIFF
--- a/yapf/pytree/continuation_splicer.py
+++ b/yapf/pytree/continuation_splicer.py
@@ -46,7 +46,7 @@ def SpliceContinuations(tree):
     for index, child in enumerate(node.children[:]):
       continuation_node = RecSplicer(child)
       if continuation_node:
-        node.children.insert(index + num_inserted, continuation_node)
+        node.insert_child(index + num_inserted, continuation_node)
         num_inserted += 1
 
   RecSplicer(tree)

--- a/yapf/pytree/subtype_assigner.py
+++ b/yapf/pytree/subtype_assigner.py
@@ -30,6 +30,7 @@ from yapf_third_party._ylib2to3.pygram import python_symbols as syms
 
 from yapf.pytree import pytree_utils
 from yapf.pytree import pytree_visitor
+from yapf.yapflib import format_token
 from yapf.yapflib import style
 from yapf.yapflib import subtypes
 
@@ -443,8 +444,9 @@ def _InsertPseudoParentheses(node):
   first = pytree_utils.FirstLeafNode(node)
   last = pytree_utils.LastLeafNode(node)
 
-  if first == last and first.type == grammar_token.COMMENT:
-    # A comment was inserted before the value, which is a pytree.Leaf.
+  if first == last and first.type in (grammar_token.COMMENT,
+                                      format_token.CONTINUATION):
+    # A comment or continuation was inserted before the value, which is a pytree.Leaf.
     # Encompass the dictionary's value into an ATOM node.
     last = first.next_sibling
     last_clone = last.clone()

--- a/yapf/yapflib/logical_line.py
+++ b/yapf/yapflib/logical_line.py
@@ -277,6 +277,9 @@ def _SpaceRequiredBetween(left, right, is_line_disabled):
   """Return True if a space is required between the left and right token."""
   lval = left.value
   rval = right.value
+  if left.is_continuation or right.is_continuation:
+    # The continuation node's value has all of the spaces it needs.
+    return False
   if (left.is_pseudo and _IsIdNumberStringToken(right) and
       left.previous_token and _IsIdNumberStringToken(left.previous_token)):
     # Space between keyword... tokens and pseudo parens.
@@ -286,9 +289,6 @@ def _SpaceRequiredBetween(left, right, is_line_disabled):
     if left.OpensScope():
       return True
     # The closing pseudo-paren shouldn't affect spacing.
-    return False
-  if left.is_continuation or right.is_continuation:
-    # The continuation node's value has all of the spaces it needs.
     return False
   if right.name in pytree_utils.NONSEMANTIC_TOKENS:
     # No space before a non-semantic token.

--- a/yapf/yapflib/reformatter.py
+++ b/yapf/yapflib/reformatter.py
@@ -405,7 +405,8 @@ def _FormatFinalLines(final_lines):
         formatted_line.append(tok.formatted_whitespace_prefix)
         formatted_line.append(tok.value)
       elif (not tok.next_token.whitespace_prefix.startswith('\n') and
-            not tok.next_token.whitespace_prefix.startswith(' ')):
+            not tok.next_token.whitespace_prefix.startswith(' ') and
+            not tok.next_token.value.startswith(' ')):
         if (tok.previous_token.value == ':' or
             tok.next_token.value not in ',}])'):
           formatted_line.append(' ')

--- a/yapftests/reformatter_basic_test.py
+++ b/yapftests/reformatter_basic_test.py
@@ -2197,6 +2197,48 @@ xxxxxxxxxxx, yyyyyyyyyyyy, vvvvvvvvv)
     finally:
       style.SetGlobalStyle(style.CreateYapfStyle())
 
+  def testStableDictionaryValueContinuation(self):
+    code = textwrap.dedent("""\
+        plan_bundles = {
+            plan_bundle.bundle_name: {
+                'tier_change_options': \\
+                bundle_util.get_tier_change_options(plan_bundle, details_by_bundle)
+            } for plan_bundle in plan.plan_bundles
+        }
+    """)
+    try:
+      style.SetGlobalStyle(
+          style.CreateStyleFromConfig('{based_on_style: google}'))
+      llines = yapf_test_helper.ParseAndUnwrap(code)
+      reformatted_code = reformatter.Reformat(llines)
+      self.assertCodeEqual(code, reformatted_code)
+
+      llines = yapf_test_helper.ParseAndUnwrap(reformatted_code)
+      reformatted_code_pass2 = reformatter.Reformat(llines)
+      self.assertCodeEqual(reformatted_code, reformatted_code_pass2)
+    finally:
+      style.SetGlobalStyle(style.CreateYapfStyle())
+
+  def testSingleLeafDictionaryValueContinuation(self):
+    code = textwrap.dedent("""\
+        d = {
+            'k': \\
+            v
+        }
+    """)
+    try:
+      style.SetGlobalStyle(
+          style.CreateStyleFromConfig('{indent_dictionary_value: true}'))
+      llines = yapf_test_helper.ParseAndUnwrap(code)
+      reformatted_code = reformatter.Reformat(llines)
+      self.assertCodeEqual(code, reformatted_code)
+
+      llines = yapf_test_helper.ParseAndUnwrap(reformatted_code)
+      reformatted_code_pass2 = reformatter.Reformat(llines)
+      self.assertCodeEqual(reformatted_code, reformatted_code_pass2)
+    finally:
+      style.SetGlobalStyle(style.CreateYapfStyle())
+
   def testDontSplitKeywordValueArguments(self):
     unformatted_code = textwrap.dedent("""\
         def mark_game_scored(gid):


### PR DESCRIPTION
### Summary
Fixes #1217 where yapf repeatedly added spaces before a line continuation backslash (`\`) in dictionary values on subsequent formatting runs (under styles enabling `INDENT_DICTIONARY_VALUE`, such as `google`). Also resolves an `AssertionError` when dictionary values consisting of a single leaf were preceded by a line continuation backslash.

### Cause & Analysis
1. **Continuation node parentage**: In `continuation_splicer.py`, continuation nodes were inserted into pytree nodes via `node.children.insert()` directly instead of `node.insert_child()`, leaving `continuation_node.parent` as `None`. Any subsequent AST transformations or sibling queries (`next_sibling`, `replace`) on these nodes could fail or raise an `AssertionError`.
2. **Continuation in dictionary values**: In `subtype_assigner.py`, `_InsertPseudoParentheses` only checked `grammar_token.COMMENT` when looking for tokens inserted before a value leaf, missing `format_token.CONTINUATION`. As a result, single-leaf values preceded by a backslash failed to be encompassed into an atom node alongside the continuation marker.
3. **Redundant whitespace emission**: In `reformatter.py`, `_FormatFinalLines` appends a space for pseudo-parentheses if the succeeding token's `whitespace_prefix` does not start with whitespace. Because continuation tokens hold their leading whitespace in their token value (`' \'`) rather than `whitespace_prefix`, `_FormatFinalLines` emitted an additional space before the continuation token on every formatting run, causing infinite drift.
4. **Token space calculation**: In `logical_line.py`, continuation tokens were checked after pseudo-parentheses in `_SpaceRequiredBetween`, allowing pseudo scope opening to request an unnecessary space before continuation markers.

### Solution
- Use `node.insert_child(...)` in `continuation_splicer.py` to maintain consistent parent links.
- Handle `format_token.CONTINUATION` alongside `grammar_token.COMMENT` in `_InsertPseudoParentheses`.
- Check `not tok.next_token.value.startswith(' ')` in `_FormatFinalLines` before appending spaces for pseudo tokens.
- Prioritize continuation token spacing checks in `logical_line._SpaceRequiredBetween`.
- Add unit tests in `reformatter_basic_test.py` verifying multiple-pass idempotency and single-leaf dictionary value continuation handling.
